### PR TITLE
Fixed language-query autocomplete issues

### DIFF
--- a/frontend/elm-package.json
+++ b/frontend/elm-package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/dom": "1.1.1 <= v < 2.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.0.0 <= v < 3.0.0",

--- a/frontend/src/Components/Home/Init.elm
+++ b/frontend/src/Components/Home/Init.elm
@@ -3,6 +3,7 @@ module Components.Home.Init exposing (init)
 import Array
 import Autocomplete as AC
 import Components.Home.Model exposing (Model)
+import Elements.Editor as Editor
 import Models.BasicTidbit as BasicTidbit
 
 
@@ -14,6 +15,7 @@ init =
     , creatingBasicTidbitData =
         { language = Nothing
         , languageQueryACState = AC.empty
+        , languageListHowManyToShow = (List.length Editor.humanReadableListOfLanguages)
         , languageQuery = ""
         , name = ""
         , description = ""

--- a/frontend/src/Components/Home/Messages.elm
+++ b/frontend/src/Components/Home/Messages.elm
@@ -11,12 +11,14 @@ import Models.Route as Route
 {-| Home Component Msg.
 -}
 type Msg
-    = GoTo Route.Route
+    = NoOp
+    | GoTo Route.Route
     | LogOut
     | OnLogOutFailure ApiError.ApiError
     | OnLogOutSuccess BasicResponse.BasicResponse
     | BasicTidbitUpdateLanguageQuery String
     | BasicTidbitUpdateACState AC.Msg
+    | BasicTidbitUpdateACWrap Bool
     | BasicTidbitSelectLanguage (Maybe String)
     | ResetCreateBasicTidbit
     | BasicTidbitUpdateName String

--- a/frontend/src/Components/Home/View.elm
+++ b/frontend/src/Components/Home/View.elm
@@ -194,7 +194,7 @@ createBasicTidbitView model shared =
                     BasicTidbitUpdateACState
                     (AC.view
                         acViewConfig
-                        8
+                        model.creatingBasicTidbitData.languageListHowManyToShow
                         model.creatingBasicTidbitData.languageQueryACState
                         (filterLanguagesByQuery
                             model.creatingBasicTidbitData.languageQuery
@@ -320,6 +320,7 @@ createBasicTidbitView model shared =
                 []
                 [ input
                     [ placeholder "language"
+                    , id "language-query-input"
                     , onInput BasicTidbitUpdateLanguageQuery
                     , value model.creatingBasicTidbitData.languageQuery
                     , disabled <|

--- a/frontend/src/Models/BasicTidbit.elm
+++ b/frontend/src/Models/BasicTidbit.elm
@@ -30,6 +30,7 @@ type alias BasicTidbit =
 type alias BasicTidbitCreateData =
     { language : Maybe Language
     , languageQueryACState : AC.State
+    , languageListHowManyToShow : Int
     , languageQuery : String
     , name : String
     , description : String
@@ -89,6 +90,7 @@ createDataCacheEncoder basicTidbitCreateData =
                 basicTidbitCreateData.language
           )
         , ( "languageQueryACState", Encode.null )
+        , ( "languageListHowManyToShow", Encode.int basicTidbitCreateData.languageListHowManyToShow )
         , ( "languageQuery", Encode.string basicTidbitCreateData.languageQuery )
         , ( "name", Encode.string basicTidbitCreateData.name )
         , ( "description", Encode.string basicTidbitCreateData.description )
@@ -115,6 +117,7 @@ createDataCacheDecoder =
     decode BasicTidbitCreateData
         |> required "language" (Decode.maybe languageCacheDecoder)
         |> required "languageQueryACState" (Decode.succeed AC.empty)
+        |> required "languageListHowManyToShow" (Decode.int)
         |> required "languageQuery" Decode.string
         |> required "name" Decode.string
         |> required "description" Decode.string


### PR DESCRIPTION
### Closes

closes #7 


### Description 

- Arrow keys now work before the mouse has been used at all
- Arrow keys now wrap around so you can cycle all the way through
- Length of how many items to show has been moved into a variable
   - It is no longer 8, but instead the max, we can use CSS to make it scrolly if
     we don't want it to look long, but otherwise languages like R just become
     impossible to select.
- When you select a new language, input box is auto-focussed to help user
- Overall design moving to pure-arrow-key-friendly