### PR TITLE
Closes #63

### DIFF
--- a/frontend/src/Components/Home/Update.elm
+++ b/frontend/src/Components/Home/Update.elm
@@ -148,6 +148,7 @@ update msg model shared =
                                 Nothing ->
                                     Ports.createCodeEditor
                                         { id = "create-bigbit-code-editor"
+                                        , fileID = ""
                                         , lang = ""
                                         , theme = User.getTheme shared.user
                                         , value = ""
@@ -164,6 +165,7 @@ update msg model shared =
                                         Just (FS.File content { language }) ->
                                             Ports.createCodeEditor
                                                 { id = "create-bigbit-code-editor"
+                                                , fileID = FS.uniqueFilePath filePath
                                                 , lang = Editor.aceLanguageLocation language
                                                 , theme = User.getTheme shared.user
                                                 , value = content
@@ -185,6 +187,7 @@ update msg model shared =
                             Cmd.batch
                                 [ Ports.createCodeEditor
                                     { id = "create-snipbit-code-editor"
+                                    , fileID = ""
                                     , lang = aceLang
                                     , theme = User.getTheme shared.user
                                     , value = model.snipbitCreateData.code
@@ -1839,6 +1842,7 @@ createViewBigbitHCCodeEditor maybeBigbit maybeRHC user =
                 editorWithRange range language code =
                     Ports.createCodeEditor
                         { id = "view-bigbit-code-editor"
+                        , fileID = ""
                         , lang = Editor.aceLanguageLocation language
                         , theme = User.getTheme user
                         , value = code
@@ -1886,6 +1890,7 @@ createViewSnipbitHCCodeEditor maybeSnipbit maybeRHC user =
                 editorWithRange range =
                     Ports.createCodeEditor
                         { id = "view-snipbit-code-editor"
+                        , fileID = ""
                         , lang = Editor.aceLanguageLocation snipbit.language
                         , theme = User.getTheme user
                         , value = snipbit.code
@@ -1918,6 +1923,7 @@ createViewSnipbitCodeEditor snipbit { route, user } =
         editorWithRange range =
             Ports.createCodeEditor
                 { id = "view-snipbit-code-editor"
+                , fileID = ""
                 , lang = Editor.aceLanguageLocation snipbit.language
                 , theme = User.getTheme user
                 , value = snipbit.code
@@ -1965,6 +1971,7 @@ createViewBigbitCodeEditor bigbit { route, user } =
         blankEditor =
             Ports.createCodeEditor
                 { id = "view-bigbit-code-editor"
+                , fileID = ""
                 , lang = ""
                 , theme = User.getTheme user
                 , value = ""
@@ -1986,6 +1993,7 @@ createViewBigbitCodeEditor bigbit { route, user } =
                         Just (FS.File content { language }) ->
                             Ports.createCodeEditor
                                 { id = "view-bigbit-code-editor"
+                                , fileID = FS.uniqueFilePath somePath
                                 , lang = Editor.aceLanguageLocation language
                                 , theme = User.getTheme user
                                 , value = content
@@ -2018,6 +2026,7 @@ createViewBigbitCodeEditor bigbit { route, user } =
                                         Just (FS.File content { language }) ->
                                             Ports.createCodeEditor
                                                 { id = "view-bigbit-code-editor"
+                                                , fileID = FS.uniqueFilePath hc.file
                                                 , lang = Editor.aceLanguageLocation language
                                                 , theme = User.getTheme user
                                                 , value = content

--- a/frontend/src/Elements/FileStructure.elm
+++ b/frontend/src/Elements/FileStructure.elm
@@ -90,7 +90,7 @@ NOTE: You should always use this to check path equality, otherwise bugs maybe
 -}
 isSameFilePath : Path -> Path -> Bool
 isSameFilePath file1 file2 =
-    (dropOptionalLeftSlash file1) == (dropOptionalLeftSlash file2)
+    (uniqueFilePath file1) == (uniqueFilePath file2)
 
 
 {-| Checks if two folder paths are the same, drops both the initial and final
@@ -101,8 +101,23 @@ NOTE: You should always use this to check path eqaulity, otherwise bugs maybe
 -}
 isSameFolderPath : Path -> Path -> Bool
 isSameFolderPath folder1 folder2 =
-    (dropOptionalRightSlash (dropOptionalLeftSlash folder1))
-        == (dropOptionalRightSlash (dropOptionalLeftSlash folder2))
+    (uniqueFolderPath folder1) == (uniqueFolderPath folder2)
+
+
+{-| Files `/bla/bla.a` and `bla/bla.a` point to the same file, this gets rid
+of the initial slash to produce a unique file name.
+-}
+uniqueFilePath : Path -> Path
+uniqueFilePath =
+    dropOptionalLeftSlash
+
+
+{-| Folders `/bla/bla/` and `bla/bla` point to the same folder, this gets rid
+of the initial and final slash to produce a unique folder name.
+-}
+uniqueFolderPath : Path -> Path
+uniqueFolderPath =
+    dropOptionalLeftSlash >> dropOptionalRightSlash
 
 
 {-| Similar to a `map`, but does not allow to change the type, only the value.

--- a/frontend/src/Ports.elm
+++ b/frontend/src/Ports.elm
@@ -29,6 +29,7 @@ port onLoadModelFromLocalStorage : (String -> msg) -> Sub msg
 
 type alias CreateCodeEditorConfig =
     { id : String
+    , fileID : String
     , lang : String
     , theme : String
     , value : String


### PR DESCRIPTION
### Closes

Closes #63

### Description

As described in the issue, now your undo/redo history is saved across frames, which feels much more natural.

Additionally, if they do refresh the page and they do lose their undo history, we now wipe the initial undo so they can't control-z and remove all their code (which we set initially). This is very important, because that initial, possibly accidental control-z would lose all their ranges.

