### PR TITLE
closes #61

### DIFF
--- a/frontend/src/Elements/Editor.scss
+++ b/frontend/src/Elements/Editor.scss
@@ -10,8 +10,8 @@
 // Ace places this class on the editor.
 .ace_editor {
   font-family: 'Inconsolata', monospace;
-  width: 635px;
-  height: 600px;
+  width: 100%;
+  height: 100%;
 }
 
 .highlight-marker {


### PR DESCRIPTION
### Closes

Closes #61 

### Description

This was a massive pain in the ass. ACE has a lot of issues with scrolling vertically/horizontally, so
had to guess and test a bit till I saw what functions even work...fucking painful.

In the end, got it worked, with scrolling vertically and horizontally, added padding at the bottom just
like in Atom so you can scroll beyond the last line of code, this also allows us to center things vertically even if they are the last line of code.

Also added a bit of padding on the right because ACE scroll bars are buggy and it doesn't let you scroll beyond a scroll bar. The added padding makes up for the scroll bar to make sure you always scroll horizontally into view (not having the scroll bar chop off part of the range).

And used a little basic calculation to always attempt to center things horizontally, the ACE api for this was broken so it had to be done manually.

