### PR TITLE
Closes #88

### DIFF
--- a/backend/src/models/tidbit.model.ts
+++ b/backend/src/models/tidbit.model.ts
@@ -1,0 +1,114 @@
+/// Module for encapsulating helper functions for the tidbit model.
+
+import * as kleen from "kleen";
+
+import { malformedFieldError, isNullOrUndefined } from '../util';
+import { ErrorCode, MongoID } from '../types';
+import { mongoIDSchema } from './kleen-schemas';
+import { Snipbit, snipbitDBActions } from './snipbit.model';
+import { Bigbit, bigbitDBActions } from './bigbit.model';
+
+
+/**
+ * The internal tidbit search filter.
+ */
+interface InternalTidbitSearchFilter {
+  author?: MongoID;
+}
+
+/**
+ * All the possible tidbits.
+ */
+export type Tidbit = Snipbit | Bigbit;
+
+/**
+* A `TidbitPointer` points to a tidbit, providing the means to retrieve the
+* tidbit when needed.
+*/
+export interface TidbitPointer {
+  tidbitType: TidbitType;
+  targetID: string;
+}
+
+/**
+* The current possible tidbit types.
+*/
+export enum TidbitType {
+  Snipbit = 1,
+  Bigbit
+}
+
+/**
+ * The filters allowed when getting tidbits.
+ */
+export interface TidbitSearchFilter {
+  forUser?: MongoID;
+}
+
+/**
+* The schema for validating a `TidbitPointer`.
+*/
+export const tidbitPointerSchema: kleen.typeSchema = {
+  objectProperties: {
+    "tidbitType": {
+      primitiveType: kleen.kindOfPrimitive.number,
+      restriction: (tidbitType: number) => {
+        if(!(tidbitType in TidbitType)) {
+          return Promise.reject({
+            errorCode: ErrorCode.storyInvalidTidbitType,
+            message: "Invalid tidbit type"
+          });
+        }
+      },
+      typeFailureError: malformedFieldError("tidbitPointer.tidbitType")
+    },
+    "targetID": mongoIDSchema(malformedFieldError("tidbitPointer.targetID")),
+  }
+};
+
+/**
+ * All the db helpers for tidbits and tidbitPointers.
+ */
+export const tidbitDBActions = {
+
+   /**
+    * Returns [a promise to] true if the `tidbitPointer` points to an existant
+    * tidbit.
+    */
+   tidbitPointerExists: (tidbitPointer: TidbitPointer): Promise<boolean> => {
+     switch(tidbitPointer.tidbitType) {
+       case TidbitType.Snipbit:
+         return snipbitDBActions.hasSnipbit(tidbitPointer.targetID);
+
+       case TidbitType.Bigbit:
+         return bigbitDBActions.hasBigbit(tidbitPointer.targetID);
+     }
+   },
+
+   /**
+    * Gets the actual tidbit from the appropriate collection.
+    */
+  expandTidbitPointer: (tidbitPointer: TidbitPointer): Promise<Tidbit> => {
+    switch(tidbitPointer.tidbitType) {
+      case TidbitType.Snipbit:
+        return snipbitDBActions.getSnipbit(tidbitPointer.targetID);
+
+      case TidbitType.Bigbit:
+        return bigbitDBActions.getBigbit(tidbitPointer.targetID);
+    }
+  },
+
+  /**
+   * Gets tidbits from the database, customizable through search filter.
+   */
+  getTidbits: (searchFilter: TidbitSearchFilter): Promise<Tidbit[]> => {
+
+    return Promise.all([snipbitDBActions.getSnipbits(searchFilter), bigbitDBActions.getBigbits(searchFilter)])
+    .then(([snipbits, bigbits]) => {
+      let tidbits: (Snipbit | Bigbit)[] = snipbits;
+      tidbits = tidbits.concat(bigbits);
+
+      return tidbits;
+    });
+  }
+}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,6 +9,7 @@ import { User, userDBActions, prepareUserForResponse } from './models/user.model
 import { Snipbit, snipbitDBActions } from './models/snipbit.model';
 import { Bigbit, bigbitDBActions } from './models/bigbit.model';
 import { NewStory, storyDBActions } from "./models/story.model";
+import { tidbitDBActions } from './models/tidbit.model';
 import { AppRoutes, AppRoutesAuth, FrontendError } from './types';
 import { internalError } from './util';
 
@@ -329,9 +330,9 @@ export const routes: AppRoutes = {
       const params = req.params;
       const storyID = params.id;
       const userID = req.user._id;
-      const newStoryPages = req.body;
+      const newStoryTidbitPointers = req.body;
 
-      handleAction(res)(storyDBActions.addTidbitsToStory(userID, storyID, newStoryPages));
+      handleAction(res)(storyDBActions.addTidbitPointersToStory(userID, storyID, newStoryTidbitPointers));
     }
   },
 
@@ -343,14 +344,7 @@ export const routes: AppRoutes = {
       const queryParams = req.query;
       const forUser = queryParams.forUser;
 
-      Promise.all([snipbitDBActions.getSnipbits({ forUser }), bigbitDBActions.getBigbits({ forUser })])
-      .then(([snipbits, bigbits]) => {
-        let tidbits: (Snipbit | Bigbit)[] = snipbits;
-        tidbits = tidbits.concat(bigbits);
-
-        res.status(200).json(tidbits);
-      })
-      .catch(handleError(res));
+      handleAction(res)(tidbitDBActions.getTidbits({ forUser }));
     }
   }
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -94,7 +94,7 @@ export enum ErrorCode {
   storyNameTooLong,
   storyDescriptionEmpty,
   storyDescriptionTooLong,
-  storyInvalidPageType,
+  storyInvalidTidbitType,
   storyEmptyTag,
   storyNoTags,
   storyDoesNotExist,

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -13,6 +13,7 @@ import Models.Snipbit as Snipbit
 import Models.Story as Story
 import Models.User as User
 import Models.Tidbit as Tidbit
+import Models.TidbitPointer as TidbitPointer
 
 
 {-| Helper for querying the API (GET), automatically adds the apiBaseUrl prefix.
@@ -169,9 +170,9 @@ postUpdateStoryInformation storyID newStoryInformation =
 
 {-| Updates a story with new tidbits.
 -}
-postAddTidbitsToStory : String -> List Story.StoryPage -> (ApiError.ApiError -> b) -> (Story.ExpandedStory -> b) -> Cmd b
-postAddTidbitsToStory storyID newTidbits =
+postAddTidbitsToStory : String -> List TidbitPointer.TidbitPointer -> (ApiError.ApiError -> b) -> (Story.ExpandedStory -> b) -> Cmd b
+postAddTidbitsToStory storyID newTidbitPointers =
     apiPost
         ("stories" :/: storyID :/: "addTidbits")
         Story.expandedStoryDecoder
-        (Encode.list <| List.map Story.storyPageEncoder newTidbits)
+        (Encode.list <| List.map TidbitPointer.encoder newTidbitPointers)

--- a/frontend/src/Components/Home/Update.elm
+++ b/frontend/src/Components/Home/Update.elm
@@ -24,6 +24,7 @@ import Models.ProfileData as ProfileData
 import Models.NewStoryData as NewStoryData
 import Models.Story as Story
 import Models.StoryData as StoryData
+import Models.Tidbit as Tidbit
 import Models.User as User exposing (defaultUserUpdateRecord)
 import Task
 import Ports
@@ -2225,7 +2226,7 @@ update msg model shared =
                 if List.length tidbits > 0 then
                     ( model
                     , shared
-                    , Api.postAddTidbitsToStory storyID (List.map Story.storyPageFromTidbit tidbits) CreateStoryPublishAddedTidbitsFailure CreateStoryGetStorySuccess
+                    , Api.postAddTidbitsToStory storyID (List.map Tidbit.compressTidbit tidbits) CreateStoryPublishAddedTidbitsFailure CreateStoryGetStorySuccess
                     )
                 else
                     -- Should never happen.

--- a/frontend/src/Components/Home/View.elm
+++ b/frontend/src/Components/Home/View.elm
@@ -1000,7 +1000,7 @@ createStoryView model shared =
                                             [ text <| toString <| index + 1 ]
                                         ]
                                 )
-                                story.expandedPages
+                                story.tidbits
                             )
                         , div
                             [ class "inline-block" ]
@@ -1051,7 +1051,7 @@ createStoryView model shared =
                                             [ text "Add" ]
                                         ]
                                 )
-                                (StoryData.remainingTidbits (story.expandedPages ++ model.storyData.tidbitsToAdd) userTidbits)
+                                (StoryData.remainingTidbits (story.tidbits ++ model.storyData.tidbitsToAdd) userTidbits)
                             )
                         ]
                     ]

--- a/frontend/src/Models/ApiError.elm
+++ b/frontend/src/Models/ApiError.elm
@@ -54,7 +54,7 @@ type ApiError
     | StoryNameTooLong
     | StoryDescriptionEmpty
     | StoryDescriptionTooLong
-    | StoryInvalidPageType
+    | StoryInvalidTidbitType
     | StoryEmptyTag
     | StoryNoTags
     | StoryDoesNotExist
@@ -213,8 +213,8 @@ humanReadable apiError =
         StoryDescriptionTooLong ->
             "Your description name is too long!"
 
-        StoryInvalidPageType ->
-            "That is not a valid story type, refer to the API for valid types!"
+        StoryInvalidTidbitType ->
+            "That is not a valid tidbit type, refer to the API for valid tidbit types!"
 
         StoryEmptyTag ->
             "You cannot have empty tags!"
@@ -364,7 +364,7 @@ fromErrorCode errorCode =
             StoryDescriptionTooLong
 
         43 ->
-            StoryInvalidPageType
+            StoryInvalidTidbitType
 
         44 ->
             StoryEmptyTag

--- a/frontend/src/Models/Tidbit.elm
+++ b/frontend/src/Models/Tidbit.elm
@@ -6,6 +6,7 @@ import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
 import Models.Snipbit as SnipbitModel
 import Models.Bigbit as BigbitModel
 import Models.Route as Route
+import Models.TidbitPointer as TidbitPointer
 
 
 {-| All the different tidbit types.
@@ -50,6 +51,22 @@ getTypeName tidbit =
 
         Bigbit _ ->
             "Bigbit"
+
+
+{-| Converts a tidbit to compressed-pointer form.
+-}
+compressTidbit : Tidbit -> TidbitPointer.TidbitPointer
+compressTidbit tidbit =
+    case tidbit of
+        Snipbit { id } ->
+            { tidbitType = TidbitPointer.Snipbit
+            , targetID = id
+            }
+
+        Bigbit { id } ->
+            { tidbitType = TidbitPointer.Bigbit
+            , targetID = id
+            }
 
 
 {-| Tidbit encoder.

--- a/frontend/src/Models/TidbitPointer.elm
+++ b/frontend/src/Models/TidbitPointer.elm
@@ -1,0 +1,75 @@
+module Models.TidbitPointer exposing (..)
+
+import Json.Encode as Encode
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+
+
+{-| A `TidbitPointer` points to a tidbit.
+-}
+type alias TidbitPointer =
+    { tidbitType : TidbitType
+    , targetID : String
+    }
+
+
+{-| The current possible tidbit types.
+-}
+type TidbitType
+    = Snipbit
+    | Bigbit
+
+
+{-| TidbitPointer encoder.
+-}
+encoder : TidbitPointer -> Encode.Value
+encoder tidbitPointer =
+    Encode.object
+        [ ( "tidbitType", tibitTypeEncoder tidbitPointer.tidbitType )
+        , ( "targetID", Encode.string tidbitPointer.targetID )
+        ]
+
+
+{-| TidbitPointer decoder.
+-}
+decoder : Decode.Decoder TidbitPointer
+decoder =
+    decode TidbitPointer
+        |> required "tidbitType" tidbitTypeDecoder
+        |> required "targetID" Decode.string
+
+
+{-| TidbitType encoder.
+
+@NOTE This matches the backend format.
+-}
+tibitTypeEncoder : TidbitType -> Encode.Value
+tibitTypeEncoder tidbitType =
+    case tidbitType of
+        Snipbit ->
+            Encode.int 1
+
+        Bigbit ->
+            Encode.int 2
+
+
+{-| TidbitType decoder.
+
+@NOTE This matches the backend format.
+-}
+tidbitTypeDecoder : Decode.Decoder TidbitType
+tidbitTypeDecoder =
+    let
+        fromIntDecoder encodedInt =
+            case encodedInt of
+                1 ->
+                    Decode.succeed Snipbit
+
+                2 ->
+                    Decode.succeed Bigbit
+
+                _ ->
+                    Decode.fail <| "That is not a valid encoded tidbitType: " ++ (toString encodedInt)
+    in
+        Decode.int
+            |> Decode.andThen fromIntDecoder


### PR DESCRIPTION
### Closes

Closes #88 

### Description

Did as described in issue, now we have `TidbitPointer`s and `Tidbit`s.

Added `tidbit.model.ts` on the backend and `TidbitPointer.elm` on the front-end. Moved a few helper methods from `story.model.ts` to `tidbit.model.ts` and similar on front-end. Also, all the naming is much more clear now.