### PR TITLE
change MongoIDStringSchema to MongoIDSchema

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "connect-mongo": "^1.2.0",
     "express": "^4.13.4",
     "express-session": "^1.13.0",
-    "kleen": "^2.0.0",
+    "kleen": "^3.0.0",
     "moment": "^2.17.1",
     "mongodb": "^2.1.7",
     "passport": "^0.3.2",

--- a/backend/src/models/completed.model.ts
+++ b/backend/src/models/completed.model.ts
@@ -4,7 +4,7 @@ import * as kleen from "kleen";
 
 import { TidbitPointer, tidbitPointerSchema } from "./tidbit.model";
 import { MongoID, MongoObjectID, ErrorCode, TargetID } from '../types';
-import { mongoStringIDSchema } from './kleen-schemas';
+import { mongoIDSchema } from './kleen-schemas';
 import { collection, toMongoObjectID, sameID } from '../db';
 import { malformedFieldError } from '../util';
 
@@ -38,7 +38,7 @@ const completedToDBSearchForm = (completed: Completed): Completed => {
 const completedSchema: kleen.objectSchema = {
   objectProperties: {
     tidbitPointer: tidbitPointerSchema,
-    user: mongoStringIDSchema(malformedFieldError("completed.user")),
+    user: mongoIDSchema(malformedFieldError("completed.user")),
   },
   typeFailureError: malformedFieldError("completed")
 }

--- a/backend/src/models/content.model.ts
+++ b/backend/src/models/content.model.ts
@@ -4,7 +4,7 @@ import { Collection, Cursor } from "mongodb";
 import * as R from "ramda";
 import * as kleen from "kleen";
 
-import { mongoStringIDSchema } from "./kleen-schemas";
+import { mongoIDSchema } from "./kleen-schemas";
 import { toMongoObjectID, paginateResults, collection } from "../db";
 import { combineArrays, isNullOrUndefined, dropNullAndUndefinedProperties, getTime, sortByAll, SortOrder, isBlankString, malformedFieldError }  from "../util";
 import { MongoID, MongoObjectID } from "../types"
@@ -82,7 +82,7 @@ export const contentPointerSchema: kleen.objectSchema = {
         if(!(contentType in ContentType)) return Promise.reject(malformedFieldError("contentType"));
       }
     },
-    contentID: mongoStringIDSchema(malformedFieldError("contentID"))
+    contentID: mongoIDSchema(malformedFieldError("contentID"))
   },
   typeFailureError: malformedFieldError("contentPointer")
 };

--- a/backend/src/models/opinion.model.ts
+++ b/backend/src/models/opinion.model.ts
@@ -3,7 +3,6 @@
 import * as kleen from "kleen";
 import { Collection } from "mongodb";
 
-import { mongoStringIDSchema } from "./kleen-schemas";
 import { malformedFieldError, internalError } from "../util";
 import { collection, toMongoObjectID } from "../db";
 import { MongoID, MongoObjectID  } from "../types";

--- a/backend/src/models/qa.model.ts
+++ b/backend/src/models/qa.model.ts
@@ -10,7 +10,7 @@ import { MongoObjectID, MongoID, ErrorCode } from "../types";
 import { collection, toMongoObjectID, renameIDField, rejectIfResultNotOK, rejectIfNoneModified, rejectIfNoneMatched, rejectIfNoneUpserted } from "../db";
 import { Range } from "./range.model";
 import { TidbitPointer, TidbitType, tidbitPointerSchema } from "./tidbit.model";
-import { stringInRange, rangeSchema, nonEmptyStringSchema, mongoStringIDSchema, booleanSchema } from "./kleen-schemas";
+import { stringInRange, rangeSchema, nonEmptyStringSchema, mongoIDSchema, booleanSchema } from "./kleen-schemas";
 
 
 /**
@@ -283,7 +283,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID),
         kleen.validModel(questionTextSchema)(questionText)
       ])
       .then(() => {
@@ -338,7 +338,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID)
       ]);
     };
 
@@ -388,7 +388,7 @@ export const qaDBActions = {
       return Promise.all([
         kleen.validModel(voteSchema)(vote),
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID)
       ]);
     }
 
@@ -434,7 +434,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID)
       ]);
     }
 
@@ -471,7 +471,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID),
         kleen.validModel(booleanSchema(malformedFieldError("pin")))(pin)
       ]);
     }
@@ -514,7 +514,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID),
         kleen.validModel(answerTextSchema)(answerText)
       ]);
     }
@@ -568,7 +568,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID)
       ]);
     };
 
@@ -616,7 +616,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID),
         kleen.validModel(answerTextSchema)(answerText)
       ]);
     }
@@ -667,7 +667,7 @@ export const qaDBActions = {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
         kleen.validModel(voteSchema)(vote),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID)
       ]);
     }
 
@@ -713,7 +713,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID)
       ]);
     }
 
@@ -750,7 +750,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID),
         kleen.validModel(booleanSchema(malformedFieldError("pin")))(pin)
       ]);
     }
@@ -793,7 +793,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID),
         kleen.validModel(commentTextSchema)(commentText)
       ]);
     }
@@ -847,7 +847,7 @@ export const qaDBActions = {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
         kleen.validModel(commentTextSchema)(commentText),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("commentID")))(commentID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("commentID")))(commentID)
       ]);
     }
 
@@ -895,7 +895,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("commentID")))(commentID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("commentID")))(commentID)
       ]);
     }
 
@@ -935,8 +935,8 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("questionID")))(questionID),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("answerID")))(answerID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("questionID")))(questionID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("answerID")))(answerID),
         kleen.validModel(commentTextSchema)(commentText)
       ]);
     }
@@ -994,7 +994,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("commentID")))(commentID),
+        kleen.validModel(mongoIDSchema(malformedFieldError("commentID")))(commentID),
         kleen.validModel(commentTextSchema)(commentText)
       ]);
     }
@@ -1043,7 +1043,7 @@ export const qaDBActions = {
     const resolveIfValid = (): Promise<any> => {
       return Promise.all([
         kleen.validModel(tidbitPointerSchema)(tidbitPointer),
-        kleen.validModel(mongoStringIDSchema(malformedFieldError("commentID")))(commentID)
+        kleen.validModel(mongoIDSchema(malformedFieldError("commentID")))(commentID)
       ]);
     }
 

--- a/backend/src/models/story.model.ts
+++ b/backend/src/models/story.model.ts
@@ -6,9 +6,9 @@ import { Collection } from 'mongodb';
 import moment from "moment";
 
 import { opinionDBActions } from "./opinion.model";
-import { renameIDField, collection, toMongoObjectID, toMongoStringID, sameID, paginateResults } from '../db';
+import { renameIDField, collection, toMongoObjectID, sameID, paginateResults } from '../db';
 import { malformedFieldError, isNullOrUndefined, dropNullAndUndefinedProperties } from '../util';
-import { mongoStringIDSchema, nameSchema, descriptionSchema, optional, tagsSchema, nonEmptyArraySchema } from "./kleen-schemas";
+import { nameSchema, descriptionSchema, optional, tagsSchema, nonEmptyArraySchema } from "./kleen-schemas";
 import { MongoID, MongoObjectID, ErrorCode, TargetID } from '../types';
 import { completedDBActions } from './completed.model';
 import { ContentSearchFilter, ContentResultManipulation, ContentType, ContentPointer, getContent, getLanguages } from "./content.model";
@@ -157,7 +157,7 @@ export const storyDBActions = {
           return completedDBActions.isCompleted(
             {
               tidbitPointer: tidbitPointer,
-              user: toMongoStringID(withCompletedForUser)
+              user: withCompletedForUser
             },
             withCompletedForUser
           );

--- a/backend/src/models/tidbit.model.ts
+++ b/backend/src/models/tidbit.model.ts
@@ -5,7 +5,7 @@ import * as R from "ramda";
 
 import { malformedFieldError, isNullOrUndefined, combineArrays, sortByAll, getTime, SortOrder } from '../util';
 import { ErrorCode, MongoID, MongoObjectID } from '../types';
-import { mongoStringIDSchema } from './kleen-schemas';
+import { mongoIDSchema } from './kleen-schemas';
 import { ContentSearchFilter, ContentResultManipulation, contentDBActions } from "./content.model";
 import { Snipbit, snipbitDBActions } from './snipbit.model';
 import { Bigbit, bigbitDBActions } from './bigbit.model';
@@ -60,7 +60,7 @@ export const tidbitPointerSchema: kleen.objectSchema = {
       },
       typeFailureError: malformedFieldError("tidbitPointer.tidbitType")
     },
-    "targetID": mongoStringIDSchema(malformedFieldError("tidbitPointer.targetID")),
+    "targetID": mongoIDSchema(malformedFieldError("tidbitPointer.targetID")),
   }
 };
 

--- a/backend/src/validifier.ts
+++ b/backend/src/validifier.ts
@@ -26,12 +26,3 @@ export const validEmail = (email: string) => /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()
 export const validPassword = (password: string) => {
   return !(isNullOrUndefined(password)) && (password.length > 6);
 }
-
-/**
- * Checks if an id is a valid mongo ID.
- *
- * Currently only checking 24 hex chars.
- */
-export const validMongoID = (id: string = ""): boolean => {
-  return /^[0-9a-fA-F]{24}$/.test(id);
-}

--- a/backend/tests/validifier.test.ts
+++ b/backend/tests/validifier.test.ts
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import R from "ramda";
 
-import { validPhone, validEmail, validPassword, validMongoID } from '../src/validifier';
+import { validPhone, validEmail, validPassword } from '../src/validifier';
 
 
 describe('Validifier', function() {
@@ -90,33 +90,6 @@ describe('Validifier', function() {
 
     it('should return false if the password is <= 6 chars', function() {
       assert.equal(false, validPassword("123456"));
-    });
-  });
-
-  describe('#validMongoID', function() {
-
-    it('should return false if the ID is undefined', function() {
-      assert.equal(false, validMongoID(undefined));
-    });
-
-    it('should return false if the ID is null', function() {
-      assert.equal(false, validMongoID(null));
-    });
-
-    it('should return false if the ID is not 24 hex chars', function() {
-      const invalidMongoIDs = ["23", "12345678901234567890123-", "12345678901234567890123G"];
-
-      R.map((invalidMongoID) => {
-        assert.equal(false, validMongoID(invalidMongoID));
-      }, invalidMongoIDs);
-    });
-
-    it('should return true if the ID is 24 hex chars ', function() {
-      const validMongoIDs = ["123456789012345678901234", "12a456F890a2345d78901234"];
-
-      R.map((aValidMongoID) => {
-        assert.equal(true, validMongoID(aValidMongoID));
-      }, validMongoIDs);
     });
   });
 });


### PR DESCRIPTION
### Closes

Closes #162 

### Description

Uses the kleen.anySchema to validate the mongoDB ObjectID. Instead of verifying the ObjectID as a 24 long string, the ObjectID.isValid method from the mongodb library is used. This allows for valid strings as well as valid ObjectID instances to be validated by the MongoIDSchema.

### Deploy Instructions

This will require an `npm install` in `backend/` because it uses the new version of `kleen`.