### PR TITLE
184 exp format

### DIFF
--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -21,7 +21,7 @@ import JSON.TidbitPointer
 import JSON.User
 import JSON.Vote
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.ApiError as ApiError
 import Models.BasicResponse as BasicResponse
@@ -51,6 +51,7 @@ import ProjectTypeAliases exposing (..)
 
 It will either error/succeed and requires handlers for both situations. The types parameters of the endpoint let you
 know what the endpoint returns.
+
 -}
 type alias Endpoint response msg =
     (ApiError.ApiError -> msg) -> (response -> msg) -> Cmd msg
@@ -208,6 +209,7 @@ type alias API msg =
 {-| The access point to the API.
 
 Currently takes the API base url as configuration (different in prod and dev).
+
 -}
 api : String -> API msg
 api apiBaseUrl =
@@ -222,358 +224,319 @@ api apiBaseUrl =
         makePOSTEndpoint url =
             HttpService.post (apiBaseUrl ++ url)
     in
-        { get =
-            { userExists =
-                (\email -> makeGETEndpoint ("userID" :/: email) (Decode.maybe Decode.string))
-            , account =
-                makeGETEndpoint "account" JSON.User.decoder
-            , stories =
-                (\queryParams ->
-                    makeGETEndpoint ("stories" ++ Util.queryParamsToString queryParams) (Decode.list <| JSON.Story.decoder)
-                )
-            , story =
-                (\storyID -> makeGETEndpoint ("stories" :/: storyID) JSON.Story.decoder)
-            , expandedStory =
-                (\storyID ->
-                    makeGETEndpoint
-                        ("stories" :/: storyID ++ Util.queryParamsToString [ ( "expandStory", Just "true" ) ])
-                        JSON.Story.expandedStoryDecoder
-                )
-            , expandedStoryWithCompleted =
-                (\storyID ->
-                    makeGETEndpoint
-                        ("stories"
-                            :/: storyID
-                            ++ Util.queryParamsToString
-                                [ ( "expandStory", Just "true" )
-                                , ( "withCompleted", Just "true" )
-                                ]
-                        )
-                        JSON.Story.expandedStoryDecoder
-                )
-            , logOut =
-                makeGETEndpoint "logOut" JSON.BasicResponse.decoder
-            , snipbit =
-                (\snipbitID -> makeGETEndpoint ("snipbits" :/: snipbitID) JSON.Snipbit.decoder)
-            , bigbit =
-                (\bigbitID -> makeGETEndpoint ("bigbits" :/: bigbitID) JSON.Bigbit.decoder)
-            , tidbits =
-                (\queryParams ->
-                    makeGETEndpoint
-                        ("tidbits" ++ (Util.queryParamsToString queryParams))
-                        (Decode.list JSON.Tidbit.decoder)
-                )
-            , content =
-                (\queryParams ->
-                    makeGETEndpoint
-                        ("content" ++ (Util.queryParamsToString queryParams))
-                        (Decode.list JSON.Content.decoder)
-                )
-            , opinion =
-                (\contentPointer ->
-                    makeGETEndpoint
-                        ("account/getOpinion"
-                            :/: (toString <| JSON.ContentPointer.contentTypeToInt contentPointer.contentType)
-                            :/: (contentPointer.contentID)
-                        )
-                        (Decode.maybe JSON.Rating.decoder)
-                )
-            , snipbitQA =
-                (\snipbitID ->
-                    makeGETEndpoint
-                        ("qa" :/: tidbitPointerToUrl { tidbitType = TidbitPointer.Snipbit, targetID = snipbitID })
-                        JSON.QA.snipbitQADecoder
-                )
-            , bigbitQA =
-                (\bigbitID ->
-                    makeGETEndpoint
-                        ("qa" :/: tidbitPointerToUrl { tidbitType = TidbitPointer.Bigbit, targetID = bigbitID })
-                        JSON.QA.bigbitQADecoder
-                )
-            }
-        , post =
-            { login =
-                (\user -> makePOSTEndpoint "login" JSON.User.decoder (JSON.User.loginEncoder user))
-            , register =
-                (\user -> makePOSTEndpoint "register" JSON.User.decoder (JSON.User.registerEncoder user))
-            , createSnipbit =
-                (\snipbit ->
-                    makePOSTEndpoint
-                        "snipbits"
-                        JSON.IDResponse.decoder
-                        (CreateSnipbitJSON.publicationEncoder snipbit)
-                )
-            , createBigbit =
-                (\bigbit ->
-                    makePOSTEndpoint
-                        "bigbits"
-                        JSON.IDResponse.decoder
-                        (CreateBigbitJSON.publicationEncoder bigbit)
-                )
-            , updateUser =
-                (\updateRecord ->
-                    makePOSTEndpoint
-                        "account"
-                        JSON.User.decoder
-                        (JSON.User.updateRecordEncoder updateRecord)
-                )
-            , createNewStory =
-                (\newStory ->
-                    makePOSTEndpoint
-                        "stories"
-                        JSON.IDResponse.decoder
-                        (JSON.Story.newStoryEncoder newStory)
-                )
-            , updateStoryInformation =
-                (\storyID newStoryInformation ->
-                    makePOSTEndpoint
-                        ("stories" :/: storyID :/: "information")
-                        JSON.IDResponse.decoder
-                        (JSON.Story.newStoryEncoder newStoryInformation)
-                )
-            , addTidbitsToStory =
-                (\storyID newTidbitPointers ->
-                    makePOSTEndpoint
-                        ("stories" :/: storyID :/: "addTidbits")
-                        JSON.Story.expandedStoryDecoder
-                        (Encode.list <| List.map JSON.TidbitPointer.encoder newTidbitPointers)
-                )
-            , addCompleted =
-                (\completed ->
-                    makePOSTEndpoint
-                        "account/addCompleted"
-                        JSON.IDResponse.decoder
-                        (JSON.Completed.encoder completed)
-                )
-            , removeCompleted =
-                (\completed ->
-                    makePOSTEndpoint
-                        "account/removeCompleted"
-                        Decode.bool
-                        (JSON.Completed.encoder completed)
-                )
-            , checkCompleted =
-                (\completed ->
-                    makePOSTEndpoint
-                        "account/checkCompleted"
-                        Decode.bool
-                        (JSON.Completed.encoder completed)
-                )
-            , addOpinion =
-                (\opinion ->
-                    makePOSTEndpoint
-                        "account/addOpinion"
-                        Decode.bool
-                        (JSON.Opinion.encoder opinion)
-                )
-            , removeOpinion =
-                (\opinion ->
-                    makePOSTEndpoint
-                        "account/removeOpinion"
-                        Decode.bool
-                        (JSON.Opinion.encoder opinion)
-                )
-            , askQuestionOnSnipbit =
-                (\snipbitID questionText codePointer ->
-                    makePOSTEndpoint
-                        ("qa/1" :/: snipbitID :/: "askQuestion")
-                        (JSON.QA.questionDecoder JSON.Range.decoder)
-                        (Encode.object
-                            [ ( "questionText", Encode.string questionText )
-                            , ( "codePointer", JSON.Range.encoder codePointer )
+    { get =
+        { userExists =
+            \email -> makeGETEndpoint ("userID" :/: email) (Decode.maybe Decode.string)
+        , account =
+            makeGETEndpoint "account" JSON.User.decoder
+        , stories =
+            \queryParams ->
+                makeGETEndpoint ("stories" ++ Util.queryParamsToString queryParams) (Decode.list <| JSON.Story.decoder)
+        , story =
+            \storyID -> makeGETEndpoint ("stories" :/: storyID) JSON.Story.decoder
+        , expandedStory =
+            \storyID ->
+                makeGETEndpoint
+                    ("stories" :/: storyID ++ Util.queryParamsToString [ ( "expandStory", Just "true" ) ])
+                    JSON.Story.expandedStoryDecoder
+        , expandedStoryWithCompleted =
+            \storyID ->
+                makeGETEndpoint
+                    ("stories"
+                        :/: storyID
+                        ++ Util.queryParamsToString
+                            [ ( "expandStory", Just "true" )
+                            , ( "withCompleted", Just "true" )
                             ]
-                        )
-                )
-            , askQuestionOnBigbit =
-                (\bigbitID questionText codePointer ->
-                    makePOSTEndpoint
-                        ("qa/2" :/: bigbitID :/: "askQuestion")
-                        (JSON.QA.questionDecoder JSON.QA.bigbitCodePointerDecoder)
-                        (Encode.object
-                            [ ( "questionText", Encode.string questionText )
-                            , ( "codePointer", JSON.QA.bigbitCodePointerEncoder codePointer )
-                            ]
-                        )
-                )
-            , editQuestionOnSnipbit =
-                (\snipbitID questionID questionText codePointer ->
-                    makePOSTEndpoint
-                        ("qa/1" :/: snipbitID :/: "editQuestion")
-                        Util.dateDecoder
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "questionText", Encode.string questionText )
-                            , ( "codePointer", JSON.Range.encoder codePointer )
-                            ]
-                        )
-                )
-            , editQuestionOnBigbit =
-                (\bigbitID questionID questionText codePointer ->
-                    makePOSTEndpoint
-                        ("qa/2" :/: bigbitID :/: "editQuestion")
-                        Util.dateDecoder
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "questionText", Encode.string questionText )
-                            , ( "codePointer", JSON.QA.bigbitCodePointerEncoder codePointer )
-                            ]
-                        )
-                )
-            , deleteQuestion =
-                (\tidbitPointer questionID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "deleteQuestion")
-                        (decode ())
-                        (Encode.object [ ( "questionID", Encode.string questionID ) ])
-                )
-            , rateQuestion =
-                (\tidbitPointer questionID vote ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "rateQuestion")
-                        (decode ())
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "vote", JSON.Vote.encoder vote )
-                            ]
-                        )
-                )
-            , removeQuestionRating =
-                (\tidbitPointer questionID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "removeQuestionRating")
-                        (decode ())
-                        (Encode.object [ ( "questionID", Encode.string questionID ) ])
-                )
-            , pinQuestion =
-                (\tidbitPointer questionID pin ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "pinQuestion")
-                        (decode ())
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "pin", Encode.bool pin )
-                            ]
-                        )
-                )
-            , answerQuestion =
-                (\tidbitPointer questionID answerText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "answerQuestion")
-                        JSON.QA.answerDecoder
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "answerText", Encode.string answerText )
-                            ]
-                        )
-                )
-            , editAnswer =
-                (\tidbitPointer answerID answerText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "editAnswer")
-                        Util.dateDecoder
-                        (Encode.object
-                            [ ( "answerID", Encode.string answerID )
-                            , ( "answerText", Encode.string answerText )
-                            ]
-                        )
-                )
-            , deleteAnswer =
-                (\tidbitPointer answerID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "deleteAnswer")
-                        (decode ())
-                        (Encode.object [ ( "answerID", Encode.string answerID ) ])
-                )
-            , rateAnswer =
-                (\tidbitPointer answerID vote ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "rateAnswer")
-                        (decode ())
-                        (Encode.object
-                            [ ( "answerID", Encode.string answerID )
-                            , ( "vote", JSON.Vote.encoder vote )
-                            ]
-                        )
-                )
-            , removeAnswerRating =
-                (\tidbitPointer answerID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "removeAnswerRating")
-                        (decode ())
-                        (Encode.object [ ( "answerID", Encode.string answerID ) ])
-                )
-            , pinAnswer =
-                (\tidbitPointer answerID pin ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "pinAnswer")
-                        (decode ())
-                        (Encode.object
-                            [ ( "answerID", Encode.string answerID )
-                            , ( "pin", Encode.bool pin )
-                            ]
-                        )
-                )
-            , commentOnQuestion =
-                (\tidbitPointer questionID commentText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "comment/question")
-                        (JSON.QA.questionCommentDecoder)
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "commentText", Encode.string commentText )
-                            ]
-                        )
-                )
-            , editQuestionComment =
-                (\tidbitPointer commentID commentText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "editComment/question")
-                        Util.dateDecoder
-                        (Encode.object
-                            [ ( "commentText", Encode.string commentText )
-                            , ( "commentID", Encode.string commentID )
-                            ]
-                        )
-                )
-            , deleteQuestionComment =
-                (\tidbitPointer commentID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "deleteComment/question")
-                        (decode ())
-                        (Encode.object [ ( "commentID", Encode.string commentID ) ])
-                )
-            , commentOnAnswer =
-                (\tidbitPointer questionID answerID commentText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "comment/answer")
-                        JSON.QA.answerCommentDecoder
-                        (Encode.object
-                            [ ( "questionID", Encode.string questionID )
-                            , ( "answerID", Encode.string answerID )
-                            , ( "commentText", Encode.string commentText )
-                            ]
-                        )
-                )
-            , editAnswerComment =
-                (\tidbitPointer commentID commentText ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "editComment/answer")
-                        Util.dateDecoder
-                        (Encode.object
-                            [ ( "commentID", Encode.string commentID )
-                            , ( "commentText", Encode.string commentText )
-                            ]
-                        )
-                )
-            , deleteAnswerComment =
-                (\tidbitPointer commentID ->
-                    makePOSTEndpoint
-                        ("qa" :/: (tidbitPointerToUrl tidbitPointer) :/: "deleteComment/answer")
-                        (decode ())
-                        (Encode.object [ ( "commentID", Encode.string commentID ) ])
-                )
-            }
+                    )
+                    JSON.Story.expandedStoryDecoder
+        , logOut =
+            makeGETEndpoint "logOut" JSON.BasicResponse.decoder
+        , snipbit =
+            \snipbitID -> makeGETEndpoint ("snipbits" :/: snipbitID) JSON.Snipbit.decoder
+        , bigbit =
+            \bigbitID -> makeGETEndpoint ("bigbits" :/: bigbitID) JSON.Bigbit.decoder
+        , tidbits =
+            \queryParams ->
+                makeGETEndpoint
+                    ("tidbits" ++ Util.queryParamsToString queryParams)
+                    (Decode.list JSON.Tidbit.decoder)
+        , content =
+            \queryParams ->
+                makeGETEndpoint
+                    ("content" ++ Util.queryParamsToString queryParams)
+                    (Decode.list JSON.Content.decoder)
+        , opinion =
+            \contentPointer ->
+                makeGETEndpoint
+                    ("account/getOpinion"
+                        :/: (toString <| JSON.ContentPointer.contentTypeToInt contentPointer.contentType)
+                        :/: contentPointer.contentID
+                    )
+                    (Decode.maybe JSON.Rating.decoder)
+        , snipbitQA =
+            \snipbitID ->
+                makeGETEndpoint
+                    ("qa" :/: tidbitPointerToUrl { tidbitType = TidbitPointer.Snipbit, targetID = snipbitID })
+                    JSON.QA.snipbitQADecoder
+        , bigbitQA =
+            \bigbitID ->
+                makeGETEndpoint
+                    ("qa" :/: tidbitPointerToUrl { tidbitType = TidbitPointer.Bigbit, targetID = bigbitID })
+                    JSON.QA.bigbitQADecoder
         }
+    , post =
+        { login =
+            \user -> makePOSTEndpoint "login" JSON.User.decoder (JSON.User.loginEncoder user)
+        , register =
+            \user -> makePOSTEndpoint "register" JSON.User.decoder (JSON.User.registerEncoder user)
+        , createSnipbit =
+            \snipbit ->
+                makePOSTEndpoint
+                    "snipbits"
+                    JSON.IDResponse.decoder
+                    (CreateSnipbitJSON.publicationEncoder snipbit)
+        , createBigbit =
+            \bigbit ->
+                makePOSTEndpoint
+                    "bigbits"
+                    JSON.IDResponse.decoder
+                    (CreateBigbitJSON.publicationEncoder bigbit)
+        , updateUser =
+            \updateRecord ->
+                makePOSTEndpoint
+                    "account"
+                    JSON.User.decoder
+                    (JSON.User.updateRecordEncoder updateRecord)
+        , createNewStory =
+            \newStory ->
+                makePOSTEndpoint
+                    "stories"
+                    JSON.IDResponse.decoder
+                    (JSON.Story.newStoryEncoder newStory)
+        , updateStoryInformation =
+            \storyID newStoryInformation ->
+                makePOSTEndpoint
+                    ("stories" :/: storyID :/: "information")
+                    JSON.IDResponse.decoder
+                    (JSON.Story.newStoryEncoder newStoryInformation)
+        , addTidbitsToStory =
+            \storyID newTidbitPointers ->
+                makePOSTEndpoint
+                    ("stories" :/: storyID :/: "addTidbits")
+                    JSON.Story.expandedStoryDecoder
+                    (Encode.list <| List.map JSON.TidbitPointer.encoder newTidbitPointers)
+        , addCompleted =
+            \completed ->
+                makePOSTEndpoint
+                    "account/addCompleted"
+                    JSON.IDResponse.decoder
+                    (JSON.Completed.encoder completed)
+        , removeCompleted =
+            \completed ->
+                makePOSTEndpoint
+                    "account/removeCompleted"
+                    Decode.bool
+                    (JSON.Completed.encoder completed)
+        , checkCompleted =
+            \completed ->
+                makePOSTEndpoint
+                    "account/checkCompleted"
+                    Decode.bool
+                    (JSON.Completed.encoder completed)
+        , addOpinion =
+            \opinion ->
+                makePOSTEndpoint
+                    "account/addOpinion"
+                    Decode.bool
+                    (JSON.Opinion.encoder opinion)
+        , removeOpinion =
+            \opinion ->
+                makePOSTEndpoint
+                    "account/removeOpinion"
+                    Decode.bool
+                    (JSON.Opinion.encoder opinion)
+        , askQuestionOnSnipbit =
+            \snipbitID questionText codePointer ->
+                makePOSTEndpoint
+                    ("qa/1" :/: snipbitID :/: "askQuestion")
+                    (JSON.QA.questionDecoder JSON.Range.decoder)
+                    (Encode.object
+                        [ ( "questionText", Encode.string questionText )
+                        , ( "codePointer", JSON.Range.encoder codePointer )
+                        ]
+                    )
+        , askQuestionOnBigbit =
+            \bigbitID questionText codePointer ->
+                makePOSTEndpoint
+                    ("qa/2" :/: bigbitID :/: "askQuestion")
+                    (JSON.QA.questionDecoder JSON.QA.bigbitCodePointerDecoder)
+                    (Encode.object
+                        [ ( "questionText", Encode.string questionText )
+                        , ( "codePointer", JSON.QA.bigbitCodePointerEncoder codePointer )
+                        ]
+                    )
+        , editQuestionOnSnipbit =
+            \snipbitID questionID questionText codePointer ->
+                makePOSTEndpoint
+                    ("qa/1" :/: snipbitID :/: "editQuestion")
+                    Util.dateDecoder
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "questionText", Encode.string questionText )
+                        , ( "codePointer", JSON.Range.encoder codePointer )
+                        ]
+                    )
+        , editQuestionOnBigbit =
+            \bigbitID questionID questionText codePointer ->
+                makePOSTEndpoint
+                    ("qa/2" :/: bigbitID :/: "editQuestion")
+                    Util.dateDecoder
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "questionText", Encode.string questionText )
+                        , ( "codePointer", JSON.QA.bigbitCodePointerEncoder codePointer )
+                        ]
+                    )
+        , deleteQuestion =
+            \tidbitPointer questionID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "deleteQuestion")
+                    (decode ())
+                    (Encode.object [ ( "questionID", Encode.string questionID ) ])
+        , rateQuestion =
+            \tidbitPointer questionID vote ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "rateQuestion")
+                    (decode ())
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "vote", JSON.Vote.encoder vote )
+                        ]
+                    )
+        , removeQuestionRating =
+            \tidbitPointer questionID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "removeQuestionRating")
+                    (decode ())
+                    (Encode.object [ ( "questionID", Encode.string questionID ) ])
+        , pinQuestion =
+            \tidbitPointer questionID pin ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "pinQuestion")
+                    (decode ())
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "pin", Encode.bool pin )
+                        ]
+                    )
+        , answerQuestion =
+            \tidbitPointer questionID answerText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "answerQuestion")
+                    JSON.QA.answerDecoder
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "answerText", Encode.string answerText )
+                        ]
+                    )
+        , editAnswer =
+            \tidbitPointer answerID answerText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "editAnswer")
+                    Util.dateDecoder
+                    (Encode.object
+                        [ ( "answerID", Encode.string answerID )
+                        , ( "answerText", Encode.string answerText )
+                        ]
+                    )
+        , deleteAnswer =
+            \tidbitPointer answerID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "deleteAnswer")
+                    (decode ())
+                    (Encode.object [ ( "answerID", Encode.string answerID ) ])
+        , rateAnswer =
+            \tidbitPointer answerID vote ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "rateAnswer")
+                    (decode ())
+                    (Encode.object
+                        [ ( "answerID", Encode.string answerID )
+                        , ( "vote", JSON.Vote.encoder vote )
+                        ]
+                    )
+        , removeAnswerRating =
+            \tidbitPointer answerID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "removeAnswerRating")
+                    (decode ())
+                    (Encode.object [ ( "answerID", Encode.string answerID ) ])
+        , pinAnswer =
+            \tidbitPointer answerID pin ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "pinAnswer")
+                    (decode ())
+                    (Encode.object
+                        [ ( "answerID", Encode.string answerID )
+                        , ( "pin", Encode.bool pin )
+                        ]
+                    )
+        , commentOnQuestion =
+            \tidbitPointer questionID commentText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "comment/question")
+                    JSON.QA.questionCommentDecoder
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "commentText", Encode.string commentText )
+                        ]
+                    )
+        , editQuestionComment =
+            \tidbitPointer commentID commentText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "editComment/question")
+                    Util.dateDecoder
+                    (Encode.object
+                        [ ( "commentText", Encode.string commentText )
+                        , ( "commentID", Encode.string commentID )
+                        ]
+                    )
+        , deleteQuestionComment =
+            \tidbitPointer commentID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "deleteComment/question")
+                    (decode ())
+                    (Encode.object [ ( "commentID", Encode.string commentID ) ])
+        , commentOnAnswer =
+            \tidbitPointer questionID answerID commentText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "comment/answer")
+                    JSON.QA.answerCommentDecoder
+                    (Encode.object
+                        [ ( "questionID", Encode.string questionID )
+                        , ( "answerID", Encode.string answerID )
+                        , ( "commentText", Encode.string commentText )
+                        ]
+                    )
+        , editAnswerComment =
+            \tidbitPointer commentID commentText ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "editComment/answer")
+                    Util.dateDecoder
+                    (Encode.object
+                        [ ( "commentID", Encode.string commentID )
+                        , ( "commentText", Encode.string commentText )
+                        ]
+                    )
+        , deleteAnswerComment =
+            \tidbitPointer commentID ->
+                makePOSTEndpoint
+                    ("qa" :/: tidbitPointerToUrl tidbitPointer :/: "deleteComment/answer")
+                    (decode ())
+                    (Encode.object [ ( "commentID", Encode.string commentID ) ])
+        }
+    }
 
 
 {-| Converts tidbit pointers to the standard URL format: "<tidbitTypeToInt>/<tidbitID>"

--- a/frontend/src/DefaultServices/ArrayExtra.elm
+++ b/frontend/src/DefaultServices/ArrayExtra.elm
@@ -16,7 +16,7 @@ update index updater array =
                 newItemAtIndex =
                     updater itemAtIndex
             in
-                Array.set
-                    index
-                    newItemAtIndex
-                    array
+            Array.set
+                index
+                newItemAtIndex
+                array

--- a/frontend/src/DefaultServices/CommonSubPageUtil.elm
+++ b/frontend/src/DefaultServices/CommonSubPageUtil.elm
@@ -2,15 +2,17 @@ module DefaultServices.CommonSubPageUtil exposing (..)
 
 import Api
 import Flags exposing (Flags)
-import Pages.Model exposing (Shared)
-import Models.RequestTracker as RT
 import Models.ApiError as ApiError
+import Models.RequestTracker as RT
+import Pages.Model exposing (Shared)
 
 
 {-| All the common utilities for manipulating `(Model, Shared)` -> `(Model, Shared, Cmd Msg)`.
 
 NOTE: It's a type wrapper around an alias (instead of just a type alias) to allow for recursion:
-  - https://github.com/elm-lang/elm-compiler/blob/0.18.0/hints/recursive-alias.md
+
+  - <https://github.com/elm-lang/elm-compiler/blob/0.18.0/hints/recursive-alias.md>
+
 -}
 type CommonSubPageUtil model shared msg
     = Common
@@ -37,6 +39,7 @@ type CommonSubPageUtil model shared msg
 
 As you can see, this declares `Shared` instead of leaving it as a type parameter, this allows us to define a few extra
 helpful functions for sub-pages.
+
 -}
 commonSubPageUtil : model -> Shared -> CommonSubPageUtil model Shared msg
 commonSubPageUtil model shared =
@@ -58,36 +61,34 @@ commonSubPageUtil model shared =
                                 )
                                 xs
             in
-                go ( model, shared, Cmd.none )
+            go ( model, shared, Cmd.none )
     in
-        Common
-            { justSetModel = (\newModel -> ( newModel, shared, Cmd.none ))
-            , justUpdateModel = (\modelUpdater -> ( modelUpdater model, shared, Cmd.none ))
-            , justSetShared = (\newShared -> ( model, newShared, Cmd.none ))
-            , justUpdateShared = (\sharedUpdater -> ( model, sharedUpdater shared, Cmd.none ))
-            , justProduceCmd = (\newCmd -> ( model, shared, newCmd ))
-            , doNothing = ( model, shared, Cmd.none )
-            , withCmd = withCmd
-            , handleAll = handleAll
-            , api = Api.api shared.flags.apiBaseUrl
-            , justSetModalError = (\apiError -> ( model, { shared | apiModalError = Just apiError }, Cmd.none ))
-            , justSetUserNeedsAuthModal =
-                (\message -> ( model, { shared | userNeedsAuthModal = Just message }, Cmd.none ))
-            , makeSingletonRequest =
-                (\trackedRequest ( newModel, newShared, newCmd ) ->
-                    if RT.isMakingRequest shared.apiRequestTracker trackedRequest then
-                        ( model, shared, Cmd.none )
-                    else
-                        ( newModel
-                        , { newShared | apiRequestTracker = RT.startRequest trackedRequest newShared.apiRequestTracker }
-                        , newCmd
-                        )
-                )
-            , andFinishRequest =
-                (\trackedRequest ( newModel, newShared, newCmd ) ->
+    Common
+        { justSetModel = \newModel -> ( newModel, shared, Cmd.none )
+        , justUpdateModel = \modelUpdater -> ( modelUpdater model, shared, Cmd.none )
+        , justSetShared = \newShared -> ( model, newShared, Cmd.none )
+        , justUpdateShared = \sharedUpdater -> ( model, sharedUpdater shared, Cmd.none )
+        , justProduceCmd = \newCmd -> ( model, shared, newCmd )
+        , doNothing = ( model, shared, Cmd.none )
+        , withCmd = withCmd
+        , handleAll = handleAll
+        , api = Api.api shared.flags.apiBaseUrl
+        , justSetModalError = \apiError -> ( model, { shared | apiModalError = Just apiError }, Cmd.none )
+        , justSetUserNeedsAuthModal =
+            \message -> ( model, { shared | userNeedsAuthModal = Just message }, Cmd.none )
+        , makeSingletonRequest =
+            \trackedRequest ( newModel, newShared, newCmd ) ->
+                if RT.isMakingRequest shared.apiRequestTracker trackedRequest then
+                    ( model, shared, Cmd.none )
+                else
                     ( newModel
-                    , { newShared | apiRequestTracker = RT.finishRequest trackedRequest newShared.apiRequestTracker }
+                    , { newShared | apiRequestTracker = RT.startRequest trackedRequest newShared.apiRequestTracker }
                     , newCmd
                     )
+        , andFinishRequest =
+            \trackedRequest ( newModel, newShared, newCmd ) ->
+                ( newModel
+                , { newShared | apiRequestTracker = RT.finishRequest trackedRequest newShared.apiRequestTracker }
+                , newCmd
                 )
-            }
+        }

--- a/frontend/src/DefaultServices/Editable.elm
+++ b/frontend/src/DefaultServices/Editable.elm
@@ -3,7 +3,7 @@ module DefaultServices.Editable exposing (..)
 -- Inspired by Corey: https://gist.github.com/coreyhaines/cf40b7dca8916b77878c97fdb5c8184e
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 
 
@@ -179,7 +179,7 @@ decoder decodeOfType =
                 |> required "value" decodeOfType
                 |> Decode.map NotEditing
     in
-        Decode.oneOf [ decodeEditing, decodeNotEditing ]
+    Decode.oneOf [ decodeEditing, decodeNotEditing ]
 
 
 {-| Returns true if the editable is in editing mode and the buffer satisfies the predicate.

--- a/frontend/src/DefaultServices/Http.elm
+++ b/frontend/src/DefaultServices/Http.elm
@@ -39,17 +39,18 @@ handleHttpResult onApiError onApiSuccess httpResult =
                 Http.BadPayload _ _ ->
                     ApiError.UnexpectedPayload
     in
-        case httpResult of
-            Ok expectedResult ->
-                onApiSuccess expectedResult
+    case httpResult of
+        Ok expectedResult ->
+            onApiSuccess expectedResult
 
-            Err httpError ->
-                onApiError (convertToApiError httpError)
+        Err httpError ->
+            onApiError (convertToApiError httpError)
 
 
 {-| A HTTP get request.
 
- - Set's `withCredentials` = `True`.
+  - Set's `withCredentials` = `True`.
+
 -}
 get : String -> Decode.Decoder a -> (ApiError.ApiError -> b) -> (a -> b) -> Cmd b
 get url decoder onApiError onApiSuccess =
@@ -70,13 +71,14 @@ get url decoder onApiError onApiSuccess =
         httpRequest =
             get url decoder
     in
-        Http.send (handleHttpResult onApiError onApiSuccess) httpRequest
+    Http.send (handleHttpResult onApiError onApiSuccess) httpRequest
 
 
 {-| A HTTP post request.
 
- - adds a JSON header
- - Set's `withCredentials` = `True`
+  - adds a JSON header
+  - Set's `withCredentials` = `True`
+
 -}
 post : String -> Decode.Decoder a -> Encode.Value -> (ApiError.ApiError -> b) -> (a -> b) -> Cmd b
 post url decoder body onApiError onApiSuccess =
@@ -97,4 +99,4 @@ post url decoder body onApiError onApiSuccess =
         httpRequest =
             post url (Http.jsonBody body) decoder
     in
-        Http.send (handleHttpResult onApiError onApiSuccess) httpRequest
+    Http.send (handleHttpResult onApiError onApiSuccess) httpRequest

--- a/frontend/src/DefaultServices/InfixFunctions.elm
+++ b/frontend/src/DefaultServices/InfixFunctions.elm
@@ -12,6 +12,7 @@ import Maybe
 {-| An alias for `Maybe.map`.
 
 Purposefully a similar ligature to |> as it has the same type but with `Maybe`.
+
 -}
 (||>) : Maybe a -> (a -> b) -> Maybe b
 (||>) maybeA func =
@@ -22,6 +23,7 @@ infixl 0 ||>
 {-| An alias for `Maybe.map`.
 
 Purposefully a similar ligature to <| as it has the same type but with `Maybe`.
+
 -}
 (<||) : (a -> b) -> Maybe a -> Maybe b
 (<||) func maybeA =
@@ -32,6 +34,7 @@ infixr 0 <||
 {-| An alias for `Maybe.andThen`.
 
 Purposefully a similar ligature to |> as it has the same type but with `Maybe`s.
+
 -}
 (|||>) : Maybe a -> (a -> Maybe b) -> Maybe b
 (|||>) maybeA func =
@@ -42,6 +45,7 @@ infixl 0 |||>
 {-| An alias for `Maybe.andThen`.
 
 Purposefully a similar ligature to <| as it has the same type but with `Maybe`s.
+
 -}
 (<|||) : (a -> Maybe b) -> Maybe a -> Maybe b
 (<|||) func maybeA =
@@ -52,6 +56,7 @@ infixr 0 <|||
 {-| An alias for `Maybe.withDefault`.
 
 Purposefully a similar ligature to `|>`, meant to be used in a `|>` chain.
+
 -}
 (?>) : Maybe a -> a -> a
 (?>) maybeA defaultA =
@@ -62,6 +67,7 @@ infixl 0 ?>
 {-| An alias for `Maybe.withDefault`.
 
 Purposefully a similar ligature to `<|`, meant to be used in a `<|` chain.
+
 -}
 (<?) : a -> Maybe a -> a
 (<?) defaultA maybeA =

--- a/frontend/src/DefaultServices/LocalStorage.elm
+++ b/frontend/src/DefaultServices/LocalStorage.elm
@@ -1,7 +1,7 @@
-module DefaultServices.LocalStorage exposing (saveModel, onLoadModel, loadModel)
+module DefaultServices.LocalStorage exposing (loadModel, onLoadModel, saveModel)
 
 import DefaultServices.Util as Util
-import Pages.JSON exposing (encoder, decoder)
+import Pages.JSON exposing (decoder, encoder)
 import Pages.Messages exposing (Msg(..))
 import Pages.Model exposing (Model)
 import Ports
@@ -57,7 +57,7 @@ saveModel model =
 -}
 onLoadModel : Model -> String -> Msg
 onLoadModel currentModel modelAsStringFromStorage =
-    case (Util.fromJsonString (decoder currentModel) modelAsStringFromStorage) of
+    case Util.fromJsonString (decoder currentModel) modelAsStringFromStorage of
         Ok model ->
             OnLoadModelFromLocalStorageSuccess model
 

--- a/frontend/src/DefaultServices/Sort.elm
+++ b/frontend/src/DefaultServices/Sort.elm
@@ -12,6 +12,7 @@ type alias Comparator t =
 {-| When you only need to sort by a single comparator.
 
 Wrapper around `List.sortWith` so all sorting can be performed with this module.
+
 -}
 sortBy : Comparator t -> List t -> List t
 sortBy comparator =
@@ -41,7 +42,7 @@ sortByAll comparators =
                                 Basics.EQ ->
                                     go restOfComparators
             in
-                go comparators
+            go comparators
         )
 
 

--- a/frontend/src/DefaultServices/Util.elm
+++ b/frontend/src/DefaultServices/Util.elm
@@ -5,9 +5,9 @@ import DefaultServices.InfixFunctions exposing (..)
 import Dict
 import Dom
 import Elements.Simple.Markdown as Markdown
-import Html exposing (Html, Attribute, div, i, text)
-import Html.Attributes exposing (hidden, class)
-import Html.Events exposing (Options, on, onWithOptions, keyCode, defaultOptions, targetValue)
+import Html exposing (Attribute, Html, div, i, text)
+import Html.Attributes exposing (class, hidden)
+import Html.Events exposing (Options, defaultOptions, keyCode, on, onWithOptions, targetValue)
 import Html.Keyed as Keyed
 import Json.Decode as Decode
 import Json.Encode as Encode
@@ -91,10 +91,10 @@ onKeydownWithOptions options keyToMsg =
                 |> keyToMsg
                 |> maybeMapWithDefault Decode.succeed (Decode.fail "")
     in
-        onWithOptions
-            "keydown"
-            options
-            (Decode.andThen decodeMsgFromKeyCode keyCode)
+    onWithOptions
+        "keydown"
+        options
+        (Decode.andThen decodeMsgFromKeyCode keyCode)
 
 
 {-| Default event handler for `keyDown` events.
@@ -107,6 +107,7 @@ onKeydown =
 {-| Event handler for `keyDown` events that also `preventDefault`.
 
 WARNING: It'll only prevent default if your function returns a message not `Nothing`.
+
 -}
 onKeydownPreventDefault : (KK.Key -> Maybe msg) -> Attribute msg
 onKeydownPreventDefault =
@@ -192,9 +193,9 @@ resultToBool result =
 {-| Given a bunch of maybe query params, turns it into a string of the query params that are actually there.
 
 Eg.
-  []  -> ""
-  [("path", Just "asdf"), ("bla", Nothing)] -> "?path=asdf"
-  [("path", Just "asdf"), ("bla", Just "bla")] -> "?path=asdf&bla=bla"
+[] -> ""
+[("path", Just "asdf"), ("bla", Nothing)] -> "?path=asdf"
+[("path", Just "asdf"), ("bla", Just "bla")] -> "?path=asdf&bla=bla"
 
 -}
 queryParamsToString : QueryParams -> String
@@ -243,6 +244,7 @@ isBlankString =
 {-| If the string is blank returns `Nothing`, otherwise `Just` the string.
 
 @refer `isBlankString`
+
 -}
 justNonBlankString : String -> Maybe String
 justNonBlankString string =
@@ -260,16 +262,17 @@ justStringInRange lower upper string =
         stringLength =
             String.length string
     in
-        if (stringLength >= lower) && (stringLength <= upper) then
-            Just string
-        else
-            Nothing
+    if (stringLength >= lower) && (stringLength <= upper) then
+        Just string
+    else
+        Nothing
 
 
 {-| Checks that a string isn't blank and is within a specific range.
 
 @refer `justStringInRange`
 @refer `justNonBlankString`
+
 -}
 justNonblankStringInRange : Int -> Int -> String -> Maybe String
 justNonblankStringInRange lower upper string =
@@ -297,6 +300,7 @@ maybeMapWithDefault func default maybeA =
 {-| Date decoder.
 
 NOTE: Will decode both dates in number-form and dates in ISO-string-form.
+
 -}
 dateDecoder : Decode.Decoder Date.Date
 dateDecoder =
@@ -313,13 +317,14 @@ dateDecoder =
             Decode.float
                 |> Decode.map Date.fromTime
     in
-        Decode.oneOf
-            [ decodeFloatDate, decodeStringDate ]
+    Decode.oneOf
+        [ decodeFloatDate, decodeStringDate ]
 
 
 {-| Encodes a date into number-form.
 
 NOTE: Compatible with `dateDecoder`.
+
 -}
 dateEncoder : Date.Date -> Encode.Value
 dateEncoder =
@@ -364,7 +369,7 @@ indexOfFirstFalse =
                     else
                         go (index + 1) xs
     in
-        go 0
+    go 0
 
 
 {-| When running multiple updates, it can be cleaner aesthetically to have it as one list as opposed to using pipes.
@@ -386,7 +391,8 @@ addUniqueNonEmptyString stringToAdd listOfStrings =
 
 {-| A semi-hack for flex-box justify-center but align-left.
 
-@REFER http://stackoverflow.com/questions/18744164/flex-box-align-last-row-to-grid
+@REFER <http://stackoverflow.com/questions/18744164/flex-box-align-last-row-to-grid>
+
 -}
 emptyFlexBoxesForAlignment : List (Html msg)
 emptyFlexBoxesForAlignment =
@@ -414,10 +420,11 @@ togglePreviewMarkdown record =
 
 xThings "thing" "s" 1 = "1 thing"
 xThings "thing" "s" 3 = "3 things"
+
 -}
 xThings : String -> String -> Int -> String
 xThings baseWord suffix number =
-    (toString number)
+    toString number
         ++ " "
         ++ (if number == 1 then
                 baseWord
@@ -432,7 +439,7 @@ limitCharsText : Int -> String -> Html msg
 limitCharsText limit string =
     div
         [ class "char-count" ]
-        [ text <| (toString <| String.length string) ++ " / " ++ (toString limit) ]
+        [ text <| (toString <| String.length string) ++ " / " ++ toString limit ]
 
 
 {-| Similar to `classList`, but for attributes, and using `Maybe` instead of a tuple.

--- a/frontend/src/Elements/Complex/AnswerQuestion.elm
+++ b/frontend/src/Elements/Complex/AnswerQuestion.elm
@@ -3,8 +3,8 @@ module Elements.Complex.AnswerQuestion exposing (..)
 import DefaultServices.Util as Util
 import Elements.Simple.Markdown as Markdown
 import Html exposing (Html, div, text, textarea)
-import Html.Attributes exposing (class, classList, value, placeholder, disabled)
-import Html.Events exposing (onInput, onClick)
+import Html.Attributes exposing (class, classList, disabled, placeholder, value)
+import Html.Events exposing (onClick, onInput)
 import Models.QA exposing (..)
 import ProjectTypeAliases exposing (..)
 
@@ -37,80 +37,80 @@ view config { previewMarkdown, showQuestion, answerText } =
         isAnswerReady =
             Util.isNotNothing maybeReadyAnswer
     in
-        div
-            [ class "answer-question" ]
-            [ div
-                [ class "link qa-top-right-link"
-                , onClick config.goToAllAnswers
-                ]
-                [ text "see all answers" ]
-            , div
-                [ classList
-                    [ ( "display-question", True )
-                    , ( "hidden", previewMarkdown )
-                    ]
-                , onClick <| config.msgTagger ToggleShowQuestion
-                ]
-                [ text <|
-                    if showQuestion then
-                        "Hide Question"
-                    else
-                        "Show Question"
-                ]
-            , Markdown.view
-                [ classList
-                    [ ( "question", True )
-                    , ( "hidden", previewMarkdown || not showQuestion )
-                    ]
-                ]
-                config.forQuestion.questionText
-            , div
-                [ classList
-                    [ ( "preview-markdown", True )
-                    , ( "previewing-markdown", previewMarkdown )
-                    , ( "hiding-question", not showQuestion )
-                    ]
-                , onClick <| config.msgTagger TogglePreviewMarkdown
-                ]
-                [ text <|
-                    if previewMarkdown then
-                        "Close Preview"
-                    else
-                        "Markdown Preview"
-                ]
-            , Util.markdownOr
-                previewMarkdown
-                answerText
-                (div
-                    []
-                    [ textarea
-                        [ classList
-                            [ ( "hiding-question", not showQuestion )
-                            , ( "cursor-progress", config.answerQuestionRequestInProgress )
-                            ]
-                        , placeholder "Answer Question"
-                        , disabled config.answerQuestionRequestInProgress
-                        , onInput (config.msgTagger << OnAnswerTextInput)
-                        , value answerText
-                        ]
-                        []
-                    , Util.limitCharsText 1000 answerText
-                    ]
-                )
-            , div
-                (Util.maybeAttributes
-                    [ Just <|
-                        classList
-                            [ ( "answer-question-submit", True )
-                            , ( "hidden", previewMarkdown )
-                            , ( "not-ready", not isAnswerReady )
-                            , ( "cursor-progress", config.answerQuestionRequestInProgress )
-                            ]
-                    , Maybe.map (onClick << config.answerQuestion) maybeReadyAnswer
-                    ]
-                )
-                [ text "Submit Answer" ]
+    div
+        [ class "answer-question" ]
+        [ div
+            [ class "link qa-top-right-link"
+            , onClick config.goToAllAnswers
             ]
+            [ text "see all answers" ]
+        , div
+            [ classList
+                [ ( "display-question", True )
+                , ( "hidden", previewMarkdown )
+                ]
+            , onClick <| config.msgTagger ToggleShowQuestion
+            ]
+            [ text <|
+                if showQuestion then
+                    "Hide Question"
+                else
+                    "Show Question"
+            ]
+        , Markdown.view
+            [ classList
+                [ ( "question", True )
+                , ( "hidden", previewMarkdown || not showQuestion )
+                ]
+            ]
+            config.forQuestion.questionText
+        , div
+            [ classList
+                [ ( "preview-markdown", True )
+                , ( "previewing-markdown", previewMarkdown )
+                , ( "hiding-question", not showQuestion )
+                ]
+            , onClick <| config.msgTagger TogglePreviewMarkdown
+            ]
+            [ text <|
+                if previewMarkdown then
+                    "Close Preview"
+                else
+                    "Markdown Preview"
+            ]
+        , Util.markdownOr
+            previewMarkdown
+            answerText
+            (div
+                []
+                [ textarea
+                    [ classList
+                        [ ( "hiding-question", not showQuestion )
+                        , ( "cursor-progress", config.answerQuestionRequestInProgress )
+                        ]
+                    , placeholder "Answer Question"
+                    , disabled config.answerQuestionRequestInProgress
+                    , onInput (config.msgTagger << OnAnswerTextInput)
+                    , value answerText
+                    ]
+                    []
+                , Util.limitCharsText 1000 answerText
+                ]
+            )
+        , div
+            (Util.maybeAttributes
+                [ Just <|
+                    classList
+                        [ ( "answer-question-submit", True )
+                        , ( "hidden", previewMarkdown )
+                        , ( "not-ready", not isAnswerReady )
+                        , ( "cursor-progress", config.answerQuestionRequestInProgress )
+                        ]
+                , Maybe.map (onClick << config.answerQuestion) maybeReadyAnswer
+                ]
+            )
+            [ text "Submit Answer" ]
+        ]
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/frontend/src/Elements/Complex/AskQuestion.elm
+++ b/frontend/src/Elements/Complex/AskQuestion.elm
@@ -4,8 +4,8 @@ import DefaultServices.InfixFunctions exposing (..)
 import DefaultServices.Util as Util
 import Elements.Simple.Markdown as Markdown
 import Html exposing (Html, div, text, textarea)
-import Html.Attributes exposing (class, classList, placeholder, value, disabled)
-import Html.Events exposing (onInput, onClick)
+import Html.Attributes exposing (class, classList, disabled, placeholder, value)
+import Html.Events exposing (onClick, onInput)
 import Models.QA exposing (..)
 import ProjectTypeAliases exposing (..)
 
@@ -45,53 +45,53 @@ view config model =
         isQuestionReady =
             Util.isNotNothing maybeReadyQuestion
     in
-        div
-            [ class "ask-question" ]
-            [ div
-                [ class "link qa-top-right-link"
-                , onClick config.goToAllQuestions
-                ]
-                [ text "see all questions" ]
-            , div
-                [ class "preview-markdown"
-                , onClick <| config.msgTagger TogglePreviewMarkdown
-                ]
-                [ text <|
-                    if model.previewMarkdown then
-                        "Close Preview"
-                    else
-                        "Markdown Preview"
-                ]
-            , if model.previewMarkdown then
-                Markdown.view [] model.questionText
-              else
-                div
-                    []
-                    [ textarea
-                        [ classList [ ( "cursor-progress", config.askQuestionRequestInProgress ) ]
-                        , placeholder "Highlight code and ask your question..."
-                        , onInput (OnQuestionTextInput >> config.msgTagger)
-                        , value model.questionText
-                        , disabled <| config.askQuestionRequestInProgress
-                        ]
-                        []
-                    , Util.limitCharsText 300 model.questionText
-                    ]
-            , div
-                (Util.maybeAttributes
-                    [ Just <|
-                        classList
-                            [ ( "ask-question-submit", True )
-                            , ( "not-ready", not isQuestionReady )
-                            , ( "hidden", model.previewMarkdown )
-                            , ( "cursor-progress", config.askQuestionRequestInProgress )
-                            ]
-                    , maybeReadyQuestion
-                        ||> (\{ codePointer, questionText } -> onClick <| config.askQuestion codePointer questionText)
-                    ]
-                )
-                [ text "Ask Question" ]
+    div
+        [ class "ask-question" ]
+        [ div
+            [ class "link qa-top-right-link"
+            , onClick config.goToAllQuestions
             ]
+            [ text "see all questions" ]
+        , div
+            [ class "preview-markdown"
+            , onClick <| config.msgTagger TogglePreviewMarkdown
+            ]
+            [ text <|
+                if model.previewMarkdown then
+                    "Close Preview"
+                else
+                    "Markdown Preview"
+            ]
+        , if model.previewMarkdown then
+            Markdown.view [] model.questionText
+          else
+            div
+                []
+                [ textarea
+                    [ classList [ ( "cursor-progress", config.askQuestionRequestInProgress ) ]
+                    , placeholder "Highlight code and ask your question..."
+                    , onInput (OnQuestionTextInput >> config.msgTagger)
+                    , value model.questionText
+                    , disabled <| config.askQuestionRequestInProgress
+                    ]
+                    []
+                , Util.limitCharsText 300 model.questionText
+                ]
+        , div
+            (Util.maybeAttributes
+                [ Just <|
+                    classList
+                        [ ( "ask-question-submit", True )
+                        , ( "not-ready", not isQuestionReady )
+                        , ( "hidden", model.previewMarkdown )
+                        , ( "cursor-progress", config.askQuestionRequestInProgress )
+                        ]
+                , maybeReadyQuestion
+                    ||> (\{ codePointer, questionText } -> onClick <| config.askQuestion codePointer questionText)
+                ]
+            )
+            [ text "Ask Question" ]
+        ]
 
 
 update : Msg -> Model codePointer -> ( Model codePointer, Cmd Msg )

--- a/frontend/src/Elements/Complex/CommentList.elm
+++ b/frontend/src/Elements/Complex/CommentList.elm
@@ -6,9 +6,9 @@ import DefaultServices.Editable as Editable
 import DefaultServices.InfixFunctions exposing (..)
 import DefaultServices.Util as Util
 import Dict
-import Html exposing (Html, div, span, i, text, textarea)
-import Html.Attributes exposing (class, classList, placeholder, value, disabled)
-import Html.Events exposing (onInput, onClick)
+import Html exposing (Html, div, i, span, text, textarea)
+import Html.Attributes exposing (class, classList, disabled, placeholder, value)
+import Html.Events exposing (onClick, onInput)
 import Models.QA exposing (..)
 import ProjectTypeAliases exposing (..)
 import Set
@@ -56,57 +56,57 @@ view config model =
         isReadyComment =
             Util.isNotNothing justReadyComment
     in
-        div
-            [ class "comment-list" ]
-            [ div
-                [ classList [ ( "comments-wrapper", True ), ( "small", config.isSmall ) ] ]
-                [ Util.keyedDiv
-                    [ class "comments" ]
-                    (if List.isEmpty config.comments then
-                        [ ( "no-comments-text"
-                          , span [ class "no-comments-text" ] [ text "No Comments" ]
-                          )
-                        ]
-                     else
-                        List.map
-                            (\comment -> ( comment.id, commentBoxView config model comment ))
-                            config.comments
-                    )
-                ]
-            , textarea
-                [ classList
-                    [ ( "new-comment-textarea", True )
-                    , ( "cursor-progress", config.submitCommentRequestInProgress )
+    div
+        [ class "comment-list" ]
+        [ div
+            [ classList [ ( "comments-wrapper", True ), ( "small", config.isSmall ) ] ]
+            [ Util.keyedDiv
+                [ class "comments" ]
+                (if List.isEmpty config.comments then
+                    [ ( "no-comments-text"
+                      , span [ class "no-comments-text" ] [ text "No Comments" ]
+                      )
                     ]
-                , onInput <| config.msgTagger << OnNewCommentTextInput
-                , placeholder <|
-                    if isLoggedIn then
-                        "Add comment..."
-                    else
-                        "Sign up or login to comment..."
-                , value model.newCommentText
-                , disabled <| not isLoggedIn || config.submitCommentRequestInProgress
-                ]
-                []
-            , Util.limitCharsText 300 model.newCommentText
-            , div
-                (Util.maybeAttributes
-                    [ Just <|
-                        classList
-                            [ ( "submit-comment", True )
-                            , ( "disabled", not isReadyComment || not isLoggedIn )
-                            , ( "cursor-progress", config.submitCommentRequestInProgress )
-                            ]
-                    , case ( isLoggedIn, justReadyComment ) of
-                        ( True, Just comment ) ->
-                            Just <| onClick <| config.newComment comment
-
-                        _ ->
-                            Nothing
-                    ]
+                 else
+                    List.map
+                        (\comment -> ( comment.id, commentBoxView config model comment ))
+                        config.comments
                 )
-                [ text "Submit Comment" ]
             ]
+        , textarea
+            [ classList
+                [ ( "new-comment-textarea", True )
+                , ( "cursor-progress", config.submitCommentRequestInProgress )
+                ]
+            , onInput <| config.msgTagger << OnNewCommentTextInput
+            , placeholder <|
+                if isLoggedIn then
+                    "Add comment..."
+                else
+                    "Sign up or login to comment..."
+            , value model.newCommentText
+            , disabled <| not isLoggedIn || config.submitCommentRequestInProgress
+            ]
+            []
+        , Util.limitCharsText 300 model.newCommentText
+        , div
+            (Util.maybeAttributes
+                [ Just <|
+                    classList
+                        [ ( "submit-comment", True )
+                        , ( "disabled", not isReadyComment || not isLoggedIn )
+                        , ( "cursor-progress", config.submitCommentRequestInProgress )
+                        ]
+                , case ( isLoggedIn, justReadyComment ) of
+                    ( True, Just comment ) ->
+                        Just <| onClick <| config.newComment comment
+
+                    _ ->
+                        Nothing
+                ]
+            )
+            [ text "Submit Comment" ]
+        ]
 
 
 commentBoxView : RenderConfig msg comment -> Model -> Comment comment -> Html msg
@@ -119,117 +119,117 @@ commentBoxView config { deletingComments, commentEdits } comment =
             Dict.get comment.id commentEdits
 
         isCommentAuthor =
-            config.userID == (Just comment.authorID)
+            config.userID == Just comment.authorID
     in
-        div
-            [ class "comment-box" ]
-            [ case maybeCommentEdit of
-                Just commentEdit ->
-                    textarea
-                        [ classList
-                            [ ( "comment-box-text-edit-mode", True )
-                            , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
-                            ]
-                        , placeholder "Edit comment..."
-                        , disabled <| config.editCommentRequestInProgress comment.id
-                        , value <| Editable.getBuffer commentEdit
-                        , onInput <| config.msgTagger << OnEditCommentInput comment.id
+    div
+        [ class "comment-box" ]
+        [ case maybeCommentEdit of
+            Just commentEdit ->
+                textarea
+                    [ classList
+                        [ ( "comment-box-text-edit-mode", True )
+                        , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
                         ]
-                        []
+                    , placeholder "Edit comment..."
+                    , disabled <| config.editCommentRequestInProgress comment.id
+                    , value <| Editable.getBuffer commentEdit
+                    , onInput <| config.msgTagger << OnEditCommentInput comment.id
+                    ]
+                    []
 
-                Nothing ->
-                    span [ class "comment-box-text" ] [ text <| comment.commentText ]
-            , div
-                [ class "comment-box-bottom" ]
-                [ if isCommentAuthor then
-                    div
-                        [ class "author-icons" ]
-                        (case maybeCommentEdit of
-                            Just commentEdit ->
-                                [ i
-                                    (Util.maybeAttributes
-                                        [ Just <|
-                                            classList
-                                                [ ( "material-icons cancel-edit", True )
-                                                , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
-                                                ]
-                                        , if config.editCommentRequestInProgress comment.id then
-                                            Nothing
-                                          else
-                                            Just <| onClick <| config.msgTagger <| CancelEditing comment.id
-                                        ]
-                                    )
-                                    [ text "cancel" ]
-                                , i
-                                    (Util.maybeAttributes
-                                        [ Just <|
-                                            classList
-                                                [ ( "material-icons submit-edit", True )
-                                                , ( "not-allowed"
-                                                  , Editable.getBuffer commentEdit
-                                                        |> Util.justNonBlankString
-                                                        |> Util.isNothing
-                                                  )
-                                                , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
-                                                ]
-                                        , Editable.getBuffer commentEdit
-                                            |> Util.justNonBlankString
-                                            ||> config.editComment comment.id
-                                            ||> onClick
-                                        ]
-                                    )
-                                    [ text "check_circle" ]
-                                ]
+            Nothing ->
+                span [ class "comment-box-text" ] [ text <| comment.commentText ]
+        , div
+            [ class "comment-box-bottom" ]
+            [ if isCommentAuthor then
+                div
+                    [ class "author-icons" ]
+                    (case maybeCommentEdit of
+                        Just commentEdit ->
+                            [ i
+                                (Util.maybeAttributes
+                                    [ Just <|
+                                        classList
+                                            [ ( "material-icons cancel-edit", True )
+                                            , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
+                                            ]
+                                    , if config.editCommentRequestInProgress comment.id then
+                                        Nothing
+                                      else
+                                        Just <| onClick <| config.msgTagger <| CancelEditing comment.id
+                                    ]
+                                )
+                                [ text "cancel" ]
+                            , i
+                                (Util.maybeAttributes
+                                    [ Just <|
+                                        classList
+                                            [ ( "material-icons submit-edit", True )
+                                            , ( "not-allowed"
+                                              , Editable.getBuffer commentEdit
+                                                    |> Util.justNonBlankString
+                                                    |> Util.isNothing
+                                              )
+                                            , ( "cursor-progress", config.editCommentRequestInProgress comment.id )
+                                            ]
+                                    , Editable.getBuffer commentEdit
+                                        |> Util.justNonBlankString
+                                        ||> config.editComment comment.id
+                                        ||> onClick
+                                    ]
+                                )
+                                [ text "check_circle" ]
+                            ]
 
-                            Nothing ->
-                                [ i
-                                    [ classList
-                                        [ ( "material-icons delete-comment", True )
-                                        , ( "delete-warning", isBeingDeleted )
-                                        , ( "cursor-progress", config.deleteCommentRequestInProgress comment.id )
-                                        ]
-                                    , onClick <|
-                                        if isBeingDeleted then
-                                            config.deleteComment comment.id
-                                        else
-                                            config.msgTagger <| AddToDeletingComments comment.id
+                        Nothing ->
+                            [ i
+                                [ classList
+                                    [ ( "material-icons delete-comment", True )
+                                    , ( "delete-warning", isBeingDeleted )
+                                    , ( "cursor-progress", config.deleteCommentRequestInProgress comment.id )
                                     ]
-                                    [ text <|
-                                        if isBeingDeleted then
-                                            "delete_forever"
-                                        else
-                                            "delete"
-                                    ]
-                                , i
-                                    (Util.maybeAttributes
-                                        [ Just <|
-                                            classList
-                                                [ ( "material-icons edit-comment", True )
-                                                , ( "cursor-progress"
-                                                  , config.deleteCommentRequestInProgress comment.id
-                                                  )
-                                                ]
-                                        , if config.deleteCommentRequestInProgress comment.id then
-                                            Nothing
-                                          else
-                                            Just <|
-                                                onClick <|
-                                                    config.msgTagger <|
-                                                        StartEditing comment.id comment.commentText
-                                        ]
-                                    )
-                                    [ text "edit_mode" ]
+                                , onClick <|
+                                    if isBeingDeleted then
+                                        config.deleteComment comment.id
+                                    else
+                                        config.msgTagger <| AddToDeletingComments comment.id
                                 ]
-                        )
-                  else
-                    span
-                        [ class "email" ]
-                        [ text <| comment.authorEmail ]
-                , span
-                    [ class "date" ]
-                    [ text <| Date.Format.format "%m/%d/%Y" comment.createdAt ]
-                ]
+                                [ text <|
+                                    if isBeingDeleted then
+                                        "delete_forever"
+                                    else
+                                        "delete"
+                                ]
+                            , i
+                                (Util.maybeAttributes
+                                    [ Just <|
+                                        classList
+                                            [ ( "material-icons edit-comment", True )
+                                            , ( "cursor-progress"
+                                              , config.deleteCommentRequestInProgress comment.id
+                                              )
+                                            ]
+                                    , if config.deleteCommentRequestInProgress comment.id then
+                                        Nothing
+                                      else
+                                        Just <|
+                                            onClick <|
+                                                config.msgTagger <|
+                                                    StartEditing comment.id comment.commentText
+                                    ]
+                                )
+                                [ text "edit_mode" ]
+                            ]
+                    )
+              else
+                span
+                    [ class "email" ]
+                    [ text <| comment.authorEmail ]
+            , span
+                [ class "date" ]
+                [ text <| Date.Format.format "%m/%d/%Y" comment.createdAt ]
             ]
+        ]
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/frontend/src/Elements/Complex/EditAnswer.elm
+++ b/frontend/src/Elements/Complex/EditAnswer.elm
@@ -4,8 +4,8 @@ import DefaultServices.Editable as Editable
 import DefaultServices.Util as Util
 import Elements.Simple.Markdown as Markdown
 import Html exposing (Html, div, text, textarea)
-import Html.Attributes exposing (class, classList, placeholder, value, disabled)
-import Html.Events exposing (onInput, onClick)
+import Html.Attributes exposing (class, classList, disabled, placeholder, value)
+import Html.Events exposing (onClick, onInput)
 import Models.QA exposing (..)
 import ProjectTypeAliases exposing (..)
 
@@ -40,77 +40,77 @@ view config ({ previewMarkdown, showQuestion } as model) =
         isAnswerReady =
             Util.isNotNothing maybeReadyAnswer
     in
-        div
-            [ class "edit-answer" ]
-            [ div
-                [ classList
-                    [ ( "display-question", True )
-                    , ( "hidden", previewMarkdown )
-                    ]
-                , onClick <| config.msgTagger ToggleShowQuestion
+    div
+        [ class "edit-answer" ]
+        [ div
+            [ classList
+                [ ( "display-question", True )
+                , ( "hidden", previewMarkdown )
                 ]
-                [ text <|
-                    if showQuestion then
-                        "Hide Question"
-                    else
-                        "Show Question"
-                ]
-            , Markdown.view
-                [ classList
-                    [ ( "question", True )
-                    , ( "hidden", previewMarkdown || not showQuestion )
-                    ]
-                ]
-                config.forQuestion.questionText
-            , div
-                [ classList
-                    [ ( "preview-markdown", True )
-                    , ( "previewing-markdown", previewMarkdown )
-                    , ( "hiding-question", not showQuestion )
-                    ]
-                , onClick <| config.msgTagger TogglePreviewMarkdown
-                ]
-                [ text <|
-                    if previewMarkdown then
-                        "Close Preview"
-                    else
-                        "Markdown Preview"
-                ]
-            , Util.markdownOr
-                previewMarkdown
-                answerText
-                (div
-                    []
-                    [ textarea
-                        [ classList
-                            [ ( "hiding-question", not showQuestion )
-                            , ( "cursor-progress", config.editAnswerRequestInProgress )
-                            ]
-                        , placeholder "Edit Answer Text"
-                        , disabled config.editAnswerRequestInProgress
-                        , value answerText
-                        , onInput (config.msgTagger << OnAnswerTextInput)
-                        ]
-                        []
-                    , Util.limitCharsText 1000 answerText
-                    ]
-                )
-            , div
-                (Util.maybeAttributes
-                    [ Just <|
-                        classList
-                            [ ( "edit-answer-submit", True )
-                            , ( "not-ready", not isAnswerReady )
-                            , ( "hidden", previewMarkdown )
-                            , ( "cursor-progress", config.editAnswerRequestInProgress )
-                            ]
-                    , Maybe.map
-                        (onClick << config.editAnswer)
-                        maybeReadyAnswer
-                    ]
-                )
-                [ text "Update Answer" ]
+            , onClick <| config.msgTagger ToggleShowQuestion
             ]
+            [ text <|
+                if showQuestion then
+                    "Hide Question"
+                else
+                    "Show Question"
+            ]
+        , Markdown.view
+            [ classList
+                [ ( "question", True )
+                , ( "hidden", previewMarkdown || not showQuestion )
+                ]
+            ]
+            config.forQuestion.questionText
+        , div
+            [ classList
+                [ ( "preview-markdown", True )
+                , ( "previewing-markdown", previewMarkdown )
+                , ( "hiding-question", not showQuestion )
+                ]
+            , onClick <| config.msgTagger TogglePreviewMarkdown
+            ]
+            [ text <|
+                if previewMarkdown then
+                    "Close Preview"
+                else
+                    "Markdown Preview"
+            ]
+        , Util.markdownOr
+            previewMarkdown
+            answerText
+            (div
+                []
+                [ textarea
+                    [ classList
+                        [ ( "hiding-question", not showQuestion )
+                        , ( "cursor-progress", config.editAnswerRequestInProgress )
+                        ]
+                    , placeholder "Edit Answer Text"
+                    , disabled config.editAnswerRequestInProgress
+                    , value answerText
+                    , onInput (config.msgTagger << OnAnswerTextInput)
+                    ]
+                    []
+                , Util.limitCharsText 1000 answerText
+                ]
+            )
+        , div
+            (Util.maybeAttributes
+                [ Just <|
+                    classList
+                        [ ( "edit-answer-submit", True )
+                        , ( "not-ready", not isAnswerReady )
+                        , ( "hidden", previewMarkdown )
+                        , ( "cursor-progress", config.editAnswerRequestInProgress )
+                        ]
+                , Maybe.map
+                    (onClick << config.editAnswer)
+                    maybeReadyAnswer
+                ]
+            )
+            [ text "Update Answer" ]
+        ]
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/frontend/src/Elements/Complex/EditQuestion.elm
+++ b/frontend/src/Elements/Complex/EditQuestion.elm
@@ -4,7 +4,7 @@ import DefaultServices.Editable as Editable
 import DefaultServices.InfixFunctions exposing (..)
 import DefaultServices.Util as Util
 import Html exposing (Html, div, text, textarea)
-import Html.Attributes exposing (class, classList, placeholder, value, disabled)
+import Html.Attributes exposing (class, classList, disabled, placeholder, value)
 import Html.Events exposing (onClick, onInput)
 import Models.QA exposing (..)
 import ProjectTypeAliases exposing (..)
@@ -47,49 +47,49 @@ view config model =
         isQuestionReady =
             Util.isNotNothing maybeReadyQuestion
     in
-        div
-            [ class "edit-question" ]
-            [ div
-                [ class "preview-markdown"
-                , onClick <| config.msgTagger TogglePreviewMarkdown
-                ]
-                [ text <|
-                    if model.previewMarkdown then
-                        "Close Preview"
-                    else
-                        "Markdown Preview"
-                ]
-            , Util.markdownOr
-                model.previewMarkdown
-                questionText
-                (div
-                    []
-                    [ textarea
-                        [ classList [ ( "cursor-progress", config.editQuestionRequestInProgress ) ]
-                        , placeholder "Edit question text..."
-                        , value questionText
-                        , onInput (OnQuestionTextInput >> config.msgTagger)
-                        , disabled <| config.editQuestionRequestInProgress
-                        ]
-                        []
-                    , Util.limitCharsText 300 questionText
-                    ]
-                )
-            , div
-                (Util.maybeAttributes
-                    [ Just <|
-                        classList
-                            [ ( "edit-question-submit", True )
-                            , ( "not-ready", not isQuestionReady )
-                            , ( "hidden", model.previewMarkdown )
-                            , ( "cursor-progress", config.editQuestionRequestInProgress )
-                            ]
-                    , maybeReadyQuestion
-                        ||> (\{ codePointer, questionText } -> onClick <| config.editQuestion questionText codePointer)
-                    ]
-                )
-                [ text "Update Question" ]
+    div
+        [ class "edit-question" ]
+        [ div
+            [ class "preview-markdown"
+            , onClick <| config.msgTagger TogglePreviewMarkdown
             ]
+            [ text <|
+                if model.previewMarkdown then
+                    "Close Preview"
+                else
+                    "Markdown Preview"
+            ]
+        , Util.markdownOr
+            model.previewMarkdown
+            questionText
+            (div
+                []
+                [ textarea
+                    [ classList [ ( "cursor-progress", config.editQuestionRequestInProgress ) ]
+                    , placeholder "Edit question text..."
+                    , value questionText
+                    , onInput (OnQuestionTextInput >> config.msgTagger)
+                    , disabled <| config.editQuestionRequestInProgress
+                    ]
+                    []
+                , Util.limitCharsText 300 questionText
+                ]
+            )
+        , div
+            (Util.maybeAttributes
+                [ Just <|
+                    classList
+                        [ ( "edit-question-submit", True )
+                        , ( "not-ready", not isQuestionReady )
+                        , ( "hidden", model.previewMarkdown )
+                        , ( "cursor-progress", config.editQuestionRequestInProgress )
+                        ]
+                , maybeReadyQuestion
+                    ||> (\{ codePointer, questionText } -> onClick <| config.editQuestion questionText codePointer)
+                ]
+            )
+            [ text "Update Question" ]
+        ]
 
 
 update : Msg -> Model codePointer -> ( Model codePointer, Cmd Msg )

--- a/frontend/src/Elements/Simple/ContentBox.elm
+++ b/frontend/src/Elements/Simple/ContentBox.elm
@@ -2,7 +2,7 @@ module Elements.Simple.ContentBox exposing (..)
 
 import DefaultServices.Util as Util
 import Elements.Simple.Editor exposing (prettyPrintLanguages)
-import Html exposing (Html, div, text, i)
+import Html exposing (Html, div, i, text)
 import Html.Attributes exposing (class, classList)
 import Html.Events exposing (onClick)
 import Models.Content exposing (..)

--- a/frontend/src/Elements/Simple/Editor.elm
+++ b/frontend/src/Elements/Simple/Editor.elm
@@ -16,6 +16,7 @@ view editorID =
 {-| The languages the Ace Editor supports.
 
 @NOTE: Keep up to date with `backend/src/models/language.model.ts`.
+
 -}
 type Language
     = ActionScript
@@ -329,7 +330,7 @@ humanReadableListOfLanguages =
 languageFromHumanReadableName : String -> Maybe Language
 languageFromHumanReadableName languageAsString =
     humanReadableListOfLanguages
-        |> List.filter (Tuple.second >> ((==) languageAsString))
+        |> List.filter (Tuple.second >> (==) languageAsString)
         |> List.head
         |> Maybe.map Tuple.first
 
@@ -344,219 +345,220 @@ prettyPrintLanguages =
 {-| Given a file name, like `bla.py`, returns the appropriate language [python].
 
 NOTE: Due to ambiguity in certain file extensions (.sql), we return a list of the possible languages it could be. An
-      empty list means it's an unsupported file extension.
+empty list means it's an unsupported file extension.
 
 NOTE: This is the fileName, not the absolute path.
+
 -}
 languagesFromFileName : String -> List Language
 languagesFromFileName fileName =
     let
         maybeSuffix =
-            ((String.split ".") >> Util.lastElem) fileName
+            (String.split "." >> Util.lastElem) fileName
     in
-        -- Fucking docker...
-        if fileName == "Dockerfile" then
-            [ DockerFile ]
-        else if not <| String.contains "." fileName then
-            []
-        else
-            case maybeSuffix of
-                Nothing ->
-                    []
+    -- Fucking docker...
+    if fileName == "Dockerfile" then
+        [ DockerFile ]
+    else if not <| String.contains "." fileName then
+        []
+    else
+        case maybeSuffix of
+            Nothing ->
+                []
 
-                Just suffix ->
-                    case suffix of
-                        "as" ->
-                            [ ActionScript ]
+            Just suffix ->
+                case suffix of
+                    "as" ->
+                        [ ActionScript ]
 
-                        "a" ->
-                            [ Ada ]
+                    "a" ->
+                        [ Ada ]
 
-                        "scpt" ->
-                            [ AppleScript ]
+                    "scpt" ->
+                        [ AppleScript ]
 
-                        "asm" ->
-                            [ AssemblyX86 ]
+                    "asm" ->
+                        [ AssemblyX86 ]
 
-                        "c" ->
-                            [ C ]
+                    "c" ->
+                        [ C ]
 
-                        "cc" ->
-                            [ CPlusPlus ]
+                    "cc" ->
+                        [ CPlusPlus ]
 
-                        "cpp" ->
-                            [ CPlusPlus ]
+                    "cpp" ->
+                        [ CPlusPlus ]
 
-                        "h" ->
-                            [ CPlusPlus ]
+                    "h" ->
+                        [ CPlusPlus ]
 
-                        "clj" ->
-                            [ Clojure ]
+                    "clj" ->
+                        [ Clojure ]
 
-                        "cljs" ->
-                            [ Clojure ]
+                    "cljs" ->
+                        [ Clojure ]
 
-                        "cljc" ->
-                            [ Clojure ]
+                    "cljc" ->
+                        [ Clojure ]
 
-                        "edn" ->
-                            [ Clojure ]
+                    "edn" ->
+                        [ Clojure ]
 
-                        "cbl" ->
-                            [ Cobol ]
+                    "cbl" ->
+                        [ Cobol ]
 
-                        "cob" ->
-                            [ Cobol ]
+                    "cob" ->
+                        [ Cobol ]
 
-                        "coffee" ->
-                            [ CoffeeScript ]
+                    "coffee" ->
+                        [ CoffeeScript ]
 
-                        "cs" ->
-                            [ CSharp ]
+                    "cs" ->
+                        [ CSharp ]
 
-                        "css" ->
-                            [ CSS ]
+                    "css" ->
+                        [ CSS ]
 
-                        "d" ->
-                            [ D ]
+                    "d" ->
+                        [ D ]
 
-                        "dart" ->
-                            [ Dart ]
+                    "dart" ->
+                        [ Dart ]
 
-                        "ex" ->
-                            [ Elixir ]
+                    "ex" ->
+                        [ Elixir ]
 
-                        "exs" ->
-                            [ Elixir ]
+                    "exs" ->
+                        [ Elixir ]
 
-                        "elm" ->
-                            [ Elm ]
+                    "elm" ->
+                        [ Elm ]
 
-                        "erl" ->
-                            [ Erlang ]
+                    "erl" ->
+                        [ Erlang ]
 
-                        "hrl" ->
-                            [ Erlang ]
+                    "hrl" ->
+                        [ Erlang ]
 
-                        "f" ->
-                            [ Fortran ]
+                    "f" ->
+                        [ Fortran ]
 
-                        "for" ->
-                            [ Fortran ]
+                    "for" ->
+                        [ Fortran ]
 
-                        "go" ->
-                            [ GoLang ]
+                    "go" ->
+                        [ GoLang ]
 
-                        "groovy" ->
-                            [ Groovy ]
+                    "groovy" ->
+                        [ Groovy ]
 
-                        "haml" ->
-                            [ HAML ]
+                    "haml" ->
+                        [ HAML ]
 
-                        "html" ->
-                            [ HTML ]
+                    "html" ->
+                        [ HTML ]
 
-                        "hs" ->
-                            [ Haskell ]
+                    "hs" ->
+                        [ Haskell ]
 
-                        "java" ->
-                            [ Java ]
+                    "java" ->
+                        [ Java ]
 
-                        "js" ->
-                            [ JavaScript ]
+                    "js" ->
+                        [ JavaScript ]
 
-                        "json" ->
-                            [ JSON ]
+                    "json" ->
+                        [ JSON ]
 
-                        "dtx" ->
-                            [ Latex ]
+                    "dtx" ->
+                        [ Latex ]
 
-                        "lpx" ->
-                            [ Latex ]
+                    "lpx" ->
+                        [ Latex ]
 
-                        "less" ->
-                            [ Less ]
+                    "less" ->
+                        [ Less ]
 
-                        "ls" ->
-                            [ LiveScript ]
+                    "ls" ->
+                        [ LiveScript ]
 
-                        "lua" ->
-                            [ Lua ]
+                    "lua" ->
+                        [ Lua ]
 
-                        "mak" ->
-                            [ Makefile ]
+                    "mak" ->
+                        [ Makefile ]
 
-                        "matlab" ->
-                            [ Matlab ]
+                    "matlab" ->
+                        [ Matlab ]
 
-                        "sql" ->
-                            [ MySQL, PGSQL, SQL, SQLServer ]
+                    "sql" ->
+                        [ MySQL, PGSQL, SQL, SQLServer ]
 
-                        "m" ->
-                            [ ObjectiveC ]
+                    "m" ->
+                        [ ObjectiveC ]
 
-                        "ml" ->
-                            [ OCaml ]
+                    "ml" ->
+                        [ OCaml ]
 
-                        "mli" ->
-                            [ OCaml ]
+                    "mli" ->
+                        [ OCaml ]
 
-                        "pas" ->
-                            [ Pascal ]
+                    "pas" ->
+                        [ Pascal ]
 
-                        "pascal" ->
-                            [ Pascal ]
+                    "pascal" ->
+                        [ Pascal ]
 
-                        "pl" ->
-                            [ Perl ]
+                    "pl" ->
+                        [ Perl ]
 
-                        "php" ->
-                            [ PHP ]
+                    "php" ->
+                        [ PHP ]
 
-                        "ps1" ->
-                            [ PowerShell ]
+                    "ps1" ->
+                        [ PowerShell ]
 
-                        "pro" ->
-                            [ Prolog ]
+                    "pro" ->
+                        [ Prolog ]
 
-                        "py" ->
-                            [ Python ]
+                    "py" ->
+                        [ Python ]
 
-                        "r" ->
-                            [ R ]
+                    "r" ->
+                        [ R ]
 
-                        "rb" ->
-                            [ Ruby ]
+                    "rb" ->
+                        [ Ruby ]
 
-                        "rs" ->
-                            [ Rust ]
+                    "rs" ->
+                        [ Rust ]
 
-                        "scss" ->
-                            [ SASS ]
+                    "scss" ->
+                        [ SASS ]
 
-                        "sass" ->
-                            [ SASS ]
+                    "sass" ->
+                        [ SASS ]
 
-                        "scala" ->
-                            [ Scala ]
+                    "scala" ->
+                        [ Scala ]
 
-                        "sc" ->
-                            [ Scala ]
+                    "sc" ->
+                        [ Scala ]
 
-                        "swift" ->
-                            [ Swift ]
+                    "swift" ->
+                        [ Swift ]
 
-                        "ts" ->
-                            [ TypeScript ]
+                    "ts" ->
+                        [ TypeScript ]
 
-                        "xml" ->
-                            [ XML ]
+                    "xml" ->
+                        [ XML ]
 
-                        "yaml" ->
-                            [ YAML ]
+                    "yaml" ->
+                        [ YAML ]
 
-                        _ ->
-                            []
+                    _ ->
+                        []
 
 
 {-| Given a language, returns the ACE location which can be used with the ACE API to set the language.
@@ -728,7 +730,7 @@ aceLanguageLocation lang =
                 YAML ->
                     "yaml"
     in
-        baseLocation ++ languagePath
+    baseLocation ++ languagePath
 
 
 {-| Given a theme, returns the location which can be used with the ACE API to set the theme.
@@ -804,4 +806,4 @@ aceThemeLocation theme =
                 XCode ->
                     "xcode"
     in
-        baseLocation ++ themeLocation
+    baseLocation ++ themeLocation

--- a/frontend/src/Elements/Simple/FileStructure.elm
+++ b/frontend/src/Elements/Simple/FileStructure.elm
@@ -2,8 +2,8 @@ module Elements.Simple.FileStructure exposing (..)
 
 import DefaultServices.Util as Util
 import Dict
-import Html exposing (Html, div, text, i)
-import Html.Attributes exposing (class, hidden, classList)
+import Html exposing (Html, div, i, text)
+import Html.Attributes exposing (class, classList, hidden)
 import Html.Events exposing (onClick)
 
 
@@ -26,6 +26,7 @@ type alias Name =
 {-| For clarity.
 
 NOTE: Paths may optionally start with a slash. All paths should be absolute.
+
 -}
 type alias Path =
     String
@@ -34,6 +35,7 @@ type alias Path =
 {-| A filestructure is where all the code and metadata is stored.
 
 NOTE: Metadata can be placed at the top level, on folders, and on files.
+
 -}
 type FileStructure fileStructureMetadata folderMetadata fileMetadata
     = FileStructure (Folder folderMetadata fileMetadata) fileStructureMetadata
@@ -83,22 +85,24 @@ isEmpty (FileStructure (Folder files subFolders metadata) fsMetaData) =
 same format.
 
 NOTE: You should always use this to check path equality, otherwise bugs maybe caused by one file having a `/` and the
-      other not.
+other not.
+
 -}
 isSameFilePath : Path -> Path -> Bool
 isSameFilePath file1 file2 =
-    (uniqueFilePath file1) == (uniqueFilePath file2)
+    uniqueFilePath file1 == uniqueFilePath file2
 
 
 {-| Checks if two folder paths are the same, drops both the initial and final optional slashes to make sure they follow
 the same format.
 
 NOTE: You should always use this to check path eqaulity, otherwise bugs maybe caused by one folder having
-      ending/starting slashes and the other not.
+ending/starting slashes and the other not.
+
 -}
 isSameFolderPath : Path -> Path -> Bool
 isSameFolderPath folder1 folder2 =
-    (uniqueFolderPath folder1) == (uniqueFolderPath folder2)
+    uniqueFolderPath folder1 == uniqueFolderPath folder2
 
 
 {-| Files `/bla/bla.a` and `bla/bla.a` point to the same file, this gets rid of the initial slash to produce a unique
@@ -127,6 +131,7 @@ posssibly modified children. Because it first changes itself then runs on it's p
 change the type itself or it would change the type of it's children and then the recursive function would be typed
 incorrectly. Use this function when you want to modify the structures values but not the structure itself (of the
 metadata, hence a b and c are fixed).
+
 -}
 valueMap :
     FileStructure a b c
@@ -159,9 +164,9 @@ valueMap ((FileStructure rootFolder metadata) as fs) folderFunc fileFunc fsFunc 
                                     folderMetadata
                            )
             in
-                FileStructure
-                    (mapOverFolderTree "" "/" rootFolder)
-                    metadata
+            FileStructure
+                (mapOverFolderTree "" "/" rootFolder)
+                metadata
 
         {- Map over all the files. -}
         fileMap : FileStructure a b c -> FileStructure a b c
@@ -183,9 +188,9 @@ valueMap ((FileStructure rootFolder metadata) as fs) folderFunc fileFunc fsFunc 
                         )
                         folderMetadata
             in
-                FileStructure
-                    (mapOverFileTree "" "/" rootFolder)
-                    metadata
+            FileStructure
+                (mapOverFileTree "" "/" rootFolder)
+                metadata
 
         fsMap : FileStructure a b c -> FileStructure a b c
         fsMap (FileStructure rootFolder fsMetadata) =
@@ -193,10 +198,10 @@ valueMap ((FileStructure rootFolder metadata) as fs) folderFunc fileFunc fsFunc 
                 rootFolder
                 (fsFunc fsMetadata)
     in
-        fs
-            |> folderMap
-            |> fileMap
-            |> fsMap
+    fs
+        |> folderMap
+        |> fileMap
+        |> fsMap
 
 
 {-| Maps over all the metadata.
@@ -215,9 +220,9 @@ metaMap aFunc bFunc cFunc (FileStructure rootFolder a) =
                 (Dict.map applyFolder folders)
                 (bFunc b)
     in
-        FileStructure
-            (applyFolder "" rootFolder)
-            (aFunc a)
+    FileStructure
+        (applyFolder "" rootFolder)
+        (aFunc a)
 
 
 {-| Drops the first char from a string if it starts with a slash.
@@ -252,16 +257,16 @@ getFolder (FileStructure rootFolder metadata) absolutePath =
 
                 a :: rest ->
                     Dict.get a folders
-                        |> Maybe.andThen ((flip followPath) rest)
+                        |> Maybe.andThen (flip followPath rest)
     in
-        if absolutePath == "/" then
-            Just rootFolder
-        else
-            absolutePath
-                |> dropOptionalLeftSlash
-                |> dropOptionalRightSlash
-                |> String.split "/"
-                |> followPath rootFolder
+    if absolutePath == "/" then
+        Just rootFolder
+    else
+        absolutePath
+            |> dropOptionalLeftSlash
+            |> dropOptionalRightSlash
+            |> String.split "/"
+            |> followPath rootFolder
 
 
 {-| Gets a specific file from the tree if it exists in the tree, otherwise `Nothing`.
@@ -280,12 +285,12 @@ getFile (FileStructure rootFolder metadata) absolutePath =
 
                 folderName :: restOfPath ->
                     Dict.get folderName folders
-                        |> Maybe.andThen ((flip followPath) restOfPath)
+                        |> Maybe.andThen (flip followPath restOfPath)
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> String.split "/"
-            |> followPath rootFolder
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> String.split "/"
+        |> followPath rootFolder
 
 
 {-| Updates a specific file if it exists.
@@ -325,11 +330,11 @@ updateFile absolutePath fileUpdater (FileStructure rootFolder metadata) =
                                 )
                                 metadata
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> String.split "/"
-            |> followAndUpdate rootFolder
-            |> ((flip FileStructure) metadata)
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> String.split "/"
+        |> followAndUpdate rootFolder
+        |> flip FileStructure metadata
 
 
 {-| Updates a specific folder if it exists.
@@ -373,24 +378,25 @@ updateFolder absolutePath folderUpdater (FileStructure rootFolder fsMetadata) =
                                 )
                                 metadata
     in
-        if absolutePath == "/" then
-            FileStructure
-                (folderUpdater rootFolder)
-                fsMetadata
-        else
-            absolutePath
-                |> dropOptionalLeftSlash
-                |> dropOptionalRightSlash
-                |> String.split "/"
-                |> followAndUpdate rootFolder
-                |> ((flip FileStructure) fsMetadata)
+    if absolutePath == "/" then
+        FileStructure
+            (folderUpdater rootFolder)
+            fsMetadata
+    else
+        absolutePath
+            |> dropOptionalLeftSlash
+            |> dropOptionalRightSlash
+            |> String.split "/"
+            |> followAndUpdate rootFolder
+            |> flip FileStructure fsMetadata
 
 
 {-| The options for adding a folder.
 
-@param forceCreateDirectories A function for creating blank directories given  a folderName, for force-creating
-                              directories.
+@param forceCreateDirectories A function for creating blank directories given a folderName, for force-creating
+directories.
 @param overwriteExisting Will only overwrite an existing folder if this is set to true.
+
 -}
 type alias AddFolderOptions b c =
     { forceCreateDirectories : Maybe (String -> Folder b c)
@@ -410,7 +416,7 @@ addFolder addFolderOptions absolutePath newFolder (FileStructure rootFolder fsMe
                     folder
 
                 [ folderName ] ->
-                    if (Dict.member folderName folders) && not addFolderOptions.overwriteExisting then
+                    if Dict.member folderName folders && not addFolderOptions.overwriteExisting then
                         folder
                     else
                         Folder
@@ -434,10 +440,10 @@ addFolder addFolderOptions absolutePath newFolder (FileStructure rootFolder fsMe
                                         newForceCreatedFolder =
                                             createFolder (createEmptyFolder folderName) restOfPath
                                     in
-                                        Folder
-                                            files
-                                            (Dict.insert folderName newForceCreatedFolder folders)
-                                            folderMetadata
+                                    Folder
+                                        files
+                                        (Dict.insert folderName newForceCreatedFolder folders)
+                                        folderMetadata
 
                         Just aFolder ->
                             Folder
@@ -449,18 +455,19 @@ addFolder addFolderOptions absolutePath newFolder (FileStructure rootFolder fsMe
                                 )
                                 folderMetadata
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> dropOptionalRightSlash
-            |> String.split "/"
-            |> createFolder rootFolder
-            |> ((flip FileStructure) fsMetadata)
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> dropOptionalRightSlash
+        |> String.split "/"
+        |> createFolder rootFolder
+        |> flip FileStructure fsMetadata
 
 
 {-| The options for adding a file.
 
 @param forceCreateDirectories Will only create directories along the way if they don't already exist if set to true.
 @param overwriteExisting Will only replace existing files if this is set to true.
+
 -}
 type alias AddFileOptions b c =
     { overwriteExisting : Bool
@@ -499,10 +506,10 @@ addFile addFileOptions absolutePath newFile (FileStructure rootFolder fsMetadata
                                         newForceCreatedFolder =
                                             createFile (createEmptyFolder folderName) restOfPath
                                     in
-                                        Folder
-                                            files
-                                            (Dict.insert folderName newForceCreatedFolder folders)
-                                            folderMetadata
+                                    Folder
+                                        files
+                                        (Dict.insert folderName newForceCreatedFolder folders)
+                                        folderMetadata
 
                         Just aFolder ->
                             Folder
@@ -514,11 +521,11 @@ addFile addFileOptions absolutePath newFile (FileStructure rootFolder fsMetadata
                                 )
                                 folderMetadata
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> String.split "/"
-            |> createFile rootFolder
-            |> ((flip FileStructure) fsMetadata)
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> String.split "/"
+        |> createFile rootFolder
+        |> flip FileStructure fsMetadata
 
 
 {-| Returns true if the fs already has that file.
@@ -563,16 +570,17 @@ removeFile absolutePath (FileStructure rootFolder fsMetadata) =
                                 (Dict.insert folderName (removeFile subFolder restOfPath) folders)
                                 folderMetadata
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> String.split "/"
-            |> removeFile rootFolder
-            |> ((flip FileStructure) fsMetadata)
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> String.split "/"
+        |> removeFile rootFolder
+        |> flip FileStructure fsMetadata
 
 
 {-| Removes a folder if it exists, otherwise returns the same FS.
 
 NOTE: You cannot delete the root of the entire tree, calling `removeFolder "/" someFS` will return `someFS`.
+
 -}
 removeFolder : Path -> FileStructure a b c -> FileStructure a b c
 removeFolder absolutePath (FileStructure rootFolder fsMetadata) =
@@ -600,12 +608,12 @@ removeFolder absolutePath (FileStructure rootFolder fsMetadata) =
                                 (Dict.insert folderName (removeFolder subFolder restOfPath) folders)
                                 folderMetadata
     in
-        absolutePath
-            |> dropOptionalLeftSlash
-            |> dropOptionalRightSlash
-            |> String.split "/"
-            |> removeFolder rootFolder
-            |> ((flip FileStructure) fsMetadata)
+    absolutePath
+        |> dropOptionalLeftSlash
+        |> dropOptionalRightSlash
+        |> String.split "/"
+        |> removeFolder rootFolder
+        |> flip FileStructure fsMetadata
 
 
 {-| Updates the fs metadata.
@@ -673,9 +681,9 @@ skeletonView renderConfig (FileStructure rootFolder fsMetadata) =
                     ]
                 ]
     in
-        div
-            [ class renderConfig.fileStructureClass ]
-            [ (renderFolder "" "/" rootFolder) ]
+    div
+        [ class renderConfig.fileStructureClass ]
+        [ renderFolder "" "/" rootFolder ]
 
 
 type alias RenderConfig msg =
@@ -694,7 +702,7 @@ view config fs =
         , subFoldersClass = "fs-sub-folders"
         , subFilesClass = "fs-sub-files"
         , renderFile =
-            (\name absolutePath fileMetadata ->
+            \name absolutePath fileMetadata ->
                 div
                     [ class "fs-file" ]
                     [ i
@@ -718,9 +726,8 @@ view config fs =
                         ]
                         [ text name ]
                     ]
-            )
         , renderFolder =
-            (\name absolutePath folderMetadata ->
+            \name absolutePath folderMetadata ->
                 div
                     [ class "fs-folder"
                     ]
@@ -739,7 +746,6 @@ view config fs =
                         ]
                         [ text <| name ++ "/" ]
                     ]
-            )
         , expandFolderIf = .isExpanded
         }
         fs

--- a/frontend/src/Elements/Simple/Markdown.elm
+++ b/frontend/src/Elements/Simple/Markdown.elm
@@ -1,6 +1,6 @@
 module Elements.Simple.Markdown exposing (..)
 
-import Html exposing (Html, Attribute, div)
+import Html exposing (Attribute, Html, div)
 import Html.Attributes exposing (class)
 import Markdown
 

--- a/frontend/src/Elements/Simple/ProgressBar.elm
+++ b/frontend/src/Elements/Simple/ProgressBar.elm
@@ -1,7 +1,7 @@
 module Elements.Simple.ProgressBar exposing (..)
 
 import DefaultServices.Util as Util
-import Html exposing (Html, div, text, i)
+import Html exposing (Html, div, i, text)
 import Html.Attributes exposing (class, classList, style)
 import Html.Events exposing (onClick)
 
@@ -82,75 +82,76 @@ view { state, maxPosition, disabledStyling, onClickMsg, allowClick, textFormat, 
 
                 Started currentFrame ->
                     if shiftLeft then
-                        100 * (toFloat currentFrame - 1) / (toFloat maxPosition)
+                        100 * (toFloat currentFrame - 1) / toFloat maxPosition
                     else
-                        100 * (toFloat currentFrame) / (toFloat maxPosition)
+                        100 * toFloat currentFrame / toFloat maxPosition
 
                 Completed ->
                     100
     in
-        div
-            ([ classList
-                [ ( "progress-bar", True )
-                , ( "selected", isStartedState state )
-                , ( "completed", isCompletedState state )
-                , ( "disabled", disabledStyling )
-                , ( "click-allowed", allowClick )
-                ]
-             ]
-                ++ if allowClick then
+    div
+        ([ classList
+            [ ( "progress-bar", True )
+            , ( "selected", isStartedState state )
+            , ( "completed", isCompletedState state )
+            , ( "disabled", disabledStyling )
+            , ( "click-allowed", allowClick )
+            ]
+         ]
+            ++ (if allowClick then
                     [ onClick onClickMsg ]
-                   else
+                else
                     []
-            )
-            [ div
-                [ classList
-                    [ ( "progress-bar-completion-bar", True )
-                    , ( "disabled", disabledStyling )
-                    ]
-                , style [ ( "width", (toString <| round <| percentComplete * 1.6) ++ "px" ) ]
+               )
+        )
+        [ div
+            [ classList
+                [ ( "progress-bar-completion-bar", True )
+                , ( "disabled", disabledStyling )
                 ]
-                []
-            , div
-                []
-                [ text <|
-                    case textFormat of
-                        Percentage ->
-                            (toString <| round <| percentComplete) ++ "%"
+            , style [ ( "width", (toString <| round <| percentComplete * 1.6) ++ "px" ) ]
+            ]
+            []
+        , div
+            []
+            [ text <|
+                case textFormat of
+                    Percentage ->
+                        (toString <| round <| percentComplete) ++ "%"
 
-                        Custom { notStarted, started, done } ->
-                            case state of
-                                NotStarted ->
-                                    notStarted
+                    Custom { notStarted, started, done } ->
+                        case state of
+                            NotStarted ->
+                                notStarted
 
-                                Started currentFrame ->
-                                    started currentFrame
+                            Started currentFrame ->
+                                started currentFrame
 
-                                Completed ->
-                                    done
-                ]
-            , div
-                [ classList
-                    [ ( "completion-symbol", True )
-                    , ( "hidden", not alreadyComplete.complete )
-                    , ( "for-story"
-                      , case alreadyComplete.for of
-                            Story ->
-                                True
+                            Completed ->
+                                done
+            ]
+        , div
+            [ classList
+                [ ( "completion-symbol", True )
+                , ( "hidden", not alreadyComplete.complete )
+                , ( "for-story"
+                  , case alreadyComplete.for of
+                        Story ->
+                            True
 
-                            _ ->
-                                False
-                      )
-                    ]
-                ]
-                [ i [ class "material-icons" ]
-                    [ text <|
-                        case alreadyComplete.for of
-                            Story ->
-                                "done_all"
-
-                            Tidbit ->
-                                "done"
-                    ]
+                        _ ->
+                            False
+                  )
                 ]
             ]
+            [ i [ class "material-icons" ]
+                [ text <|
+                    case alreadyComplete.for of
+                        Story ->
+                            "done_all"
+
+                        Tidbit ->
+                            "done"
+                ]
+            ]
+        ]

--- a/frontend/src/Elements/Simple/QuestionList.elm
+++ b/frontend/src/Elements/Simple/QuestionList.elm
@@ -1,7 +1,7 @@
 module Elements.Simple.QuestionList exposing (..)
 
 import DefaultServices.Util as Util
-import Html exposing (Html, div, text, i, hr)
+import Html exposing (Html, div, hr, i, text)
 import Html.Attributes exposing (class, classList)
 import Html.Events exposing (onClick)
 import Models.QA as QA

--- a/frontend/src/Elements/Simple/Tags.elm
+++ b/frontend/src/Elements/Simple/Tags.elm
@@ -1,6 +1,6 @@
 module Elements.Simple.Tags exposing (..)
 
-import Html exposing (Html, div, button, text)
+import Html exposing (Html, button, div, text)
 import Html.Attributes exposing (class)
 import Html.Events exposing (onClick)
 

--- a/frontend/src/Flags.elm
+++ b/frontend/src/Flags.elm
@@ -1,5 +1,7 @@
 module Flags exposing (Flags)
 
+{-| -}
+
 
 {-| The flags passed to the program from javascript upon init.
 -}

--- a/frontend/src/JSON/ApiError.elm
+++ b/frontend/src/JSON/ApiError.elm
@@ -1,8 +1,8 @@
 module JSON.ApiError exposing (..)
 
-import Json.Encode as Encode
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
+import Json.Encode as Encode
 import Models.ApiError exposing (..)
 
 
@@ -178,4 +178,4 @@ decoder =
         backendErrorToApiError { errorCode } =
             fromErrorCode errorCode
     in
-        Decode.map backendErrorToApiError backendDecoder
+    Decode.map backendErrorToApiError backendDecoder

--- a/frontend/src/JSON/BasicResponse.elm
+++ b/frontend/src/JSON/BasicResponse.elm
@@ -1,7 +1,7 @@
 module JSON.BasicResponse exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.BasicResponse exposing (..)
 

--- a/frontend/src/JSON/Bigbit.elm
+++ b/frontend/src/JSON/Bigbit.elm
@@ -6,7 +6,7 @@ import JSON.FileStructure
 import JSON.Language
 import JSON.Range
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Bigbit exposing (..)
 
@@ -23,22 +23,22 @@ encoder bigbit =
                 (\fileMetadata -> Encode.object [ ( "language", JSON.Language.encoder fileMetadata.language ) ])
                 fs
     in
-        Encode.object
-            [ ( "name", Encode.string bigbit.name )
-            , ( "description", Encode.string bigbit.description )
-            , ( "tags", Encode.list <| List.map Encode.string bigbit.tags )
-            , ( "introduction", Encode.string bigbit.introduction )
-            , ( "conclusion", Encode.string bigbit.conclusion )
-            , ( "fs", fsEncoder bigbit.fs )
-            , ( "highlightedComments", Encode.array <| Array.map highlightedCommentEncoder bigbit.highlightedComments )
-            , ( "author", Encode.string bigbit.author )
-            , ( "authorEmail", Encode.string bigbit.authorEmail )
-            , ( "id", Encode.string bigbit.id )
-            , ( "createdAt", Util.dateEncoder bigbit.createdAt )
-            , ( "lastModified", Util.dateEncoder bigbit.lastModified )
-            , ( "languages", Encode.list <| List.map JSON.Language.encoder bigbit.languages )
-            , ( "likes", Encode.int bigbit.likes )
-            ]
+    Encode.object
+        [ ( "name", Encode.string bigbit.name )
+        , ( "description", Encode.string bigbit.description )
+        , ( "tags", Encode.list <| List.map Encode.string bigbit.tags )
+        , ( "introduction", Encode.string bigbit.introduction )
+        , ( "conclusion", Encode.string bigbit.conclusion )
+        , ( "fs", fsEncoder bigbit.fs )
+        , ( "highlightedComments", Encode.array <| Array.map highlightedCommentEncoder bigbit.highlightedComments )
+        , ( "author", Encode.string bigbit.author )
+        , ( "authorEmail", Encode.string bigbit.authorEmail )
+        , ( "id", Encode.string bigbit.id )
+        , ( "createdAt", Util.dateEncoder bigbit.createdAt )
+        , ( "lastModified", Util.dateEncoder bigbit.lastModified )
+        , ( "languages", Encode.list <| List.map JSON.Language.encoder bigbit.languages )
+        , ( "likes", Encode.int bigbit.likes )
+        ]
 
 
 {-| `Bigbit` decoder.
@@ -58,22 +58,22 @@ decoder =
                     |> required "language" JSON.Language.decoder
                 )
     in
-        decode Bigbit
-            |> required "name" Decode.string
-            |> required "description" Decode.string
-            |> required "tags" (Decode.list Decode.string)
-            |> required "introduction" Decode.string
-            |> required "conclusion" Decode.string
-            |> required "fs" fsDecoder
-            |> required "highlightedComments" (Decode.array highlightedCommentDecoder)
-            |> required "author" Decode.string
-            |> required "authorEmail" Decode.string
-            |> required "id" Decode.string
-            |> required "createdAt" Util.dateDecoder
-            |> required "lastModified" Util.dateDecoder
-            |> required "languages" (Decode.list JSON.Language.decoder)
-            -- Optional for backwards compatibility.
-            |> optional "likes" Decode.int 0
+    decode Bigbit
+        |> required "name" Decode.string
+        |> required "description" Decode.string
+        |> required "tags" (Decode.list Decode.string)
+        |> required "introduction" Decode.string
+        |> required "conclusion" Decode.string
+        |> required "fs" fsDecoder
+        |> required "highlightedComments" (Decode.array highlightedCommentDecoder)
+        |> required "author" Decode.string
+        |> required "authorEmail" Decode.string
+        |> required "id" Decode.string
+        |> required "createdAt" Util.dateDecoder
+        |> required "lastModified" Util.dateDecoder
+        |> required "languages" (Decode.list JSON.Language.decoder)
+        -- Optional for backwards compatibility.
+        |> optional "likes" Decode.int 0
 
 
 {-| `HighlightedComment` encoder.

--- a/frontend/src/JSON/Completed.elm
+++ b/frontend/src/JSON/Completed.elm
@@ -2,7 +2,7 @@ module JSON.Completed exposing (..)
 
 import JSON.TidbitPointer
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Completed exposing (..)
 

--- a/frontend/src/JSON/Content.elm
+++ b/frontend/src/JSON/Content.elm
@@ -4,7 +4,7 @@ import JSON.Bigbit
 import JSON.Snipbit
 import JSON.Story
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Content exposing (..)
 
@@ -26,4 +26,4 @@ decoder =
         decodeStory =
             Decode.map Story JSON.Story.decoder
     in
-        Decode.oneOf [ decodeSnipbit, decodeBigbit, decodeStory ]
+    Decode.oneOf [ decodeSnipbit, decodeBigbit, decodeStory ]

--- a/frontend/src/JSON/ContentPointer.elm
+++ b/frontend/src/JSON/ContentPointer.elm
@@ -1,7 +1,7 @@
 module JSON.ContentPointer exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.ContentPointer exposing (..)
 
@@ -28,6 +28,7 @@ decoder =
 {-| `ContentType` encoder.
 
 Parallel to backend `ContentType` enum.
+
 -}
 contentTypeEncoder : ContentType -> Encode.Value
 contentTypeEncoder =
@@ -37,6 +38,7 @@ contentTypeEncoder =
 {-| `ContentType` decoder.
 
 Parallel to backend `ContentType` enum.
+
 -}
 contentTypeDecoder : Decode.Decoder ContentType
 contentTypeDecoder =
@@ -53,9 +55,9 @@ contentTypeDecoder =
                     Decode.succeed Story
 
                 _ ->
-                    Decode.fail <| (toString encodedInt) ++ " is not a valid encoded content type!"
+                    Decode.fail <| toString encodedInt ++ " is not a valid encoded content type!"
     in
-        Decode.int |> Decode.andThen fromIntDecoder
+    Decode.int |> Decode.andThen fromIntDecoder
 
 
 {-| This maps exactly to the `ContentType` enum on the backend.

--- a/frontend/src/JSON/FileStructure.elm
+++ b/frontend/src/JSON/FileStructure.elm
@@ -3,13 +3,14 @@ module JSON.FileStructure exposing (..)
 import DefaultServices.Util as Util
 import Elements.Simple.FileStructure exposing (..)
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 
 
 {-| `File` encoder.
 
 Requires encoder for `fileMetadata`.
+
 -}
 fileEncoder : (fileMetadata -> Encode.Value) -> File fileMetadata -> Encode.Value
 fileEncoder fileMetadataEncoder (File content fileMetadata) =
@@ -22,6 +23,7 @@ fileEncoder fileMetadataEncoder (File content fileMetadata) =
 {-| `Folder` encoder.
 
 Requires encoder for `folderMetadata` and `fileMetadata`.
+
 -}
 folderEncoder :
     (folderMetadata -> Encode.Value)
@@ -39,6 +41,7 @@ folderEncoder folderMetadataEncoder fileMetadataEncoder (Folder files folders fo
 {-| `FileStructure` encoder.
 
 Requires `fsMetadata`/`folderMetadata`/`fileMetadata` encoders.
+
 -}
 encoder :
     (fsMetadata -> Encode.Value)
@@ -56,6 +59,7 @@ encoder fsMetadataEncoder folderMetadataEncoder fileMetadataEncoder (FileStructu
 {-| `File` decoder.
 
 Requires `fileMetadata` encoder.
+
 -}
 fileDecoder : Decode.Decoder fileMetadata -> Decode.Decoder (File fileMetadata)
 fileDecoder fileMetadataDecoder =
@@ -67,6 +71,7 @@ fileDecoder fileMetadataDecoder =
 {-| `Folder` decoder.
 
 Requires decoder for `fileMetadata` and `folderMetadata`.
+
 -}
 folderDecoder :
     Decode.Decoder folderMetadata
@@ -75,13 +80,14 @@ folderDecoder :
 folderDecoder folderMetadataDecoder fileMetadataDecoder =
     decode Folder
         |> required "files" (Util.decodeStringDict (fileDecoder fileMetadataDecoder))
-        |> required "folders" (Util.decodeStringDict (Decode.lazy (\_ -> (folderDecoder folderMetadataDecoder fileMetadataDecoder))))
+        |> required "folders" (Util.decodeStringDict (Decode.lazy (\_ -> folderDecoder folderMetadataDecoder fileMetadataDecoder)))
         |> required "folderMetadata" folderMetadataDecoder
 
 
 {-| `FileStructure` decoder.
 
 Requires `fsMetadata`/`folderMetadata`/`fileMetadata` decoders.
+
 -}
 decoder :
     Decode.Decoder fsMetadata

--- a/frontend/src/JSON/IDResponse.elm
+++ b/frontend/src/JSON/IDResponse.elm
@@ -1,7 +1,7 @@
 module JSON.IDResponse exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.IDResponse exposing (..)
 

--- a/frontend/src/JSON/Language.elm
+++ b/frontend/src/JSON/Language.elm
@@ -2,7 +2,7 @@ module JSON.Language exposing (..)
 
 import Elements.Simple.Editor exposing (..)
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 
 
@@ -183,5 +183,5 @@ decoder =
                 _ ->
                     Decode.fail <| encodedLanguage ++ " is not a valid encoded string."
     in
-        Decode.string
-            |> Decode.andThen fromStringDecoder
+    Decode.string
+        |> Decode.andThen fromStringDecoder

--- a/frontend/src/JSON/Opinion.elm
+++ b/frontend/src/JSON/Opinion.elm
@@ -1,11 +1,11 @@
 module JSON.Opinion exposing (..)
 
 import DefaultServices.Util as Util
-import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
-import Json.Encode as Encode
 import JSON.ContentPointer
 import JSON.Rating
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
+import Json.Encode as Encode
 import Models.Opinion exposing (..)
 
 

--- a/frontend/src/JSON/QA.elm
+++ b/frontend/src/JSON/QA.elm
@@ -4,7 +4,7 @@ import DefaultServices.Editable as Editable
 import DefaultServices.Util as Util
 import JSON.Range
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.QA exposing (..)
 import Set
@@ -176,19 +176,19 @@ tidbitQAStateEncoder codePointerEncoder qaState =
                 , ( "showQuestion", Encode.null )
                 ]
     in
-        Encode.object
-            [ ( "browsingCodePointer", Util.justValueOrNull codePointerEncoder qaState.browsingCodePointer )
-            , ( "newQuestion", newQuestionEncoder qaState.newQuestion )
-            , ( "questionEdits", Util.encodeStringDict questionEditEncoder qaState.questionEdits )
-            , ( "newAnswers", Util.encodeStringDict newAnswerEncoder qaState.newAnswers )
-            , ( "answerEdits", Util.encodeStringDict answerEditEncoder qaState.answerEdits )
-            , ( "newQuestionComments", stringToStringDictEncoder qaState.newQuestionComments )
-            , ( "newAnswerComments", stringToStringDictEncoder qaState.newAnswerComments )
-            , ( "questionCommentEdits", stringToEditableStringDictEncoder qaState.questionCommentEdits )
-            , ( "answerCommentEdits", stringToEditableStringDictEncoder qaState.answerCommentEdits )
-            , ( "deletingComments", Encode.null )
-            , ( "deletingAnswers", Encode.null )
-            ]
+    Encode.object
+        [ ( "browsingCodePointer", Util.justValueOrNull codePointerEncoder qaState.browsingCodePointer )
+        , ( "newQuestion", newQuestionEncoder qaState.newQuestion )
+        , ( "questionEdits", Util.encodeStringDict questionEditEncoder qaState.questionEdits )
+        , ( "newAnswers", Util.encodeStringDict newAnswerEncoder qaState.newAnswers )
+        , ( "answerEdits", Util.encodeStringDict answerEditEncoder qaState.answerEdits )
+        , ( "newQuestionComments", stringToStringDictEncoder qaState.newQuestionComments )
+        , ( "newAnswerComments", stringToStringDictEncoder qaState.newAnswerComments )
+        , ( "questionCommentEdits", stringToEditableStringDictEncoder qaState.questionCommentEdits )
+        , ( "answerCommentEdits", stringToEditableStringDictEncoder qaState.answerCommentEdits )
+        , ( "deletingComments", Encode.null )
+        , ( "deletingAnswers", Encode.null )
+        ]
 
 
 {-| `QAState` decoder.
@@ -236,15 +236,15 @@ tidbitQAStateDecoder codePointerDecoder =
                 |> hardcoded False
                 |> hardcoded True
     in
-        decode TidbitQAState
-            |> required "browsingCodePointer" (Decode.maybe codePointerDecoder)
-            |> required "newQuestion" newQuestionDecoder
-            |> required "questionEdits" (Util.decodeStringDict questionEditDecoder)
-            |> required "newAnswers" (Util.decodeStringDict newAnswerDecoder)
-            |> required "answerEdits" (Util.decodeStringDict answerEditDecoder)
-            |> required "newQuestionComments" stringToStringDictDecoder
-            |> required "newAnswerComments" stringToStringDictDecoder
-            |> required "questionCommentEdits" stringToEditableStringDictDecoder
-            |> required "answerCommentEdits" stringToEditableStringDictDecoder
-            |> hardcoded Set.empty
-            |> hardcoded Set.empty
+    decode TidbitQAState
+        |> required "browsingCodePointer" (Decode.maybe codePointerDecoder)
+        |> required "newQuestion" newQuestionDecoder
+        |> required "questionEdits" (Util.decodeStringDict questionEditDecoder)
+        |> required "newAnswers" (Util.decodeStringDict newAnswerDecoder)
+        |> required "answerEdits" (Util.decodeStringDict answerEditDecoder)
+        |> required "newQuestionComments" stringToStringDictDecoder
+        |> required "newAnswerComments" stringToStringDictDecoder
+        |> required "questionCommentEdits" stringToEditableStringDictDecoder
+        |> required "answerCommentEdits" stringToEditableStringDictDecoder
+        |> hardcoded Set.empty
+        |> hardcoded Set.empty

--- a/frontend/src/JSON/Range.elm
+++ b/frontend/src/JSON/Range.elm
@@ -1,7 +1,7 @@
 module JSON.Range exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Range exposing (..)
 

--- a/frontend/src/JSON/Rating.elm
+++ b/frontend/src/JSON/Rating.elm
@@ -1,7 +1,7 @@
 module JSON.Rating exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Rating exposing (..)
 
@@ -9,6 +9,7 @@ import Models.Rating exposing (..)
 {-| `Rating` encoder.
 
 Parallels to the backend `Rating` enum.
+
 -}
 encoder : Rating -> Encode.Value
 encoder =
@@ -18,6 +19,7 @@ encoder =
 {-| `Rating` decoder.
 
 Parallels to the backend `Rating` enum.
+
 -}
 decoder : Decode.Decoder Rating
 decoder =
@@ -28,9 +30,9 @@ decoder =
                     Decode.succeed Like
 
                 _ ->
-                    Decode.fail <| (toString encodedInt) ++ " is not a valid encoded rating!"
+                    Decode.fail <| toString encodedInt ++ " is not a valid encoded rating!"
     in
-        Decode.int |> Decode.andThen fromIntDecoder
+    Decode.int |> Decode.andThen fromIntDecoder
 
 
 {-| This maps exactly to the `Rating` enum on the backend.

--- a/frontend/src/JSON/Route.elm
+++ b/frontend/src/JSON/Route.elm
@@ -1,7 +1,7 @@
 module JSON.Route exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Route exposing (..)
 
@@ -40,12 +40,12 @@ decoder =
                 maybeRoute =
                     parseLocation <| fakeLocation encodedHash
             in
-                case maybeRoute of
-                    Nothing ->
-                        Decode.fail <| encodedHash ++ " is not a valid encoded hash!"
+            case maybeRoute of
+                Nothing ->
+                    Decode.fail <| encodedHash ++ " is not a valid encoded hash!"
 
-                    Just aRoute ->
-                        Decode.succeed aRoute
+                Just aRoute ->
+                    Decode.succeed aRoute
     in
-        Decode.string
-            |> Decode.andThen fromStringDecoder
+    Decode.string
+        |> Decode.andThen fromStringDecoder

--- a/frontend/src/JSON/Snipbit.elm
+++ b/frontend/src/JSON/Snipbit.elm
@@ -5,7 +5,7 @@ import DefaultServices.Util as Util
 import JSON.Language
 import JSON.Range
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Snipbit exposing (..)
 

--- a/frontend/src/JSON/Story.elm
+++ b/frontend/src/JSON/Story.elm
@@ -5,7 +5,7 @@ import JSON.Language
 import JSON.Tidbit
 import JSON.TidbitPointer
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Story exposing (..)
 

--- a/frontend/src/JSON/Tidbit.elm
+++ b/frontend/src/JSON/Tidbit.elm
@@ -3,7 +3,7 @@ module JSON.Tidbit exposing (..)
 import JSON.Bigbit
 import JSON.Snipbit
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Tidbit exposing (..)
 
@@ -33,4 +33,4 @@ decoder =
         decodeBigbit =
             Decode.map Bigbit JSON.Bigbit.decoder
     in
-        Decode.oneOf [ decodeSnipbit, decodeBigbit ]
+    Decode.oneOf [ decodeSnipbit, decodeBigbit ]

--- a/frontend/src/JSON/TidbitPointer.elm
+++ b/frontend/src/JSON/TidbitPointer.elm
@@ -1,7 +1,7 @@
 module JSON.TidbitPointer exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.TidbitPointer exposing (..)
 
@@ -28,6 +28,7 @@ decoder =
 {-| `TidbitType` encoder.
 
 @NOTE This matches the backend format.
+
 -}
 tibitTypeEncoder : TidbitType -> Encode.Value
 tibitTypeEncoder tidbitType =
@@ -37,6 +38,7 @@ tibitTypeEncoder tidbitType =
 {-| `TidbitType` decoder.
 
 @NOTE This matches the backend format.
+
 -}
 tidbitTypeDecoder : Decode.Decoder TidbitType
 tidbitTypeDecoder =
@@ -50,10 +52,10 @@ tidbitTypeDecoder =
                     Decode.succeed Bigbit
 
                 _ ->
-                    Decode.fail <| "That is not a valid encoded tidbitType: " ++ (toString encodedInt)
+                    Decode.fail <| "That is not a valid encoded tidbitType: " ++ toString encodedInt
     in
-        Decode.int
-            |> Decode.andThen fromIntDecoder
+    Decode.int
+        |> Decode.andThen fromIntDecoder
 
 
 {-| Converts a tidbitType to an int, matches the format of the backend.

--- a/frontend/src/JSON/TidbitType.elm
+++ b/frontend/src/JSON/TidbitType.elm
@@ -1,7 +1,7 @@
 module JSON.TidbitType exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.TidbitType exposing (..)
 
@@ -29,5 +29,5 @@ decoder =
                 _ ->
                     Decode.fail <| encodedTidbitType ++ " is not a valid encoded tidbit type."
     in
-        Decode.string
-            |> Decode.andThen fromStringDecoder
+    Decode.string
+        |> Decode.andThen fromStringDecoder

--- a/frontend/src/JSON/TutorialBookmark.elm
+++ b/frontend/src/JSON/TutorialBookmark.elm
@@ -1,7 +1,7 @@
 module JSON.TutorialBookmark exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.TutorialBookmark exposing (..)
 
@@ -48,4 +48,4 @@ decoder =
                     else
                         decodeFailure encodedBookmark
     in
-        Decode.string |> Decode.andThen fromStringDecoder
+    Decode.string |> Decode.andThen fromStringDecoder

--- a/frontend/src/JSON/User.elm
+++ b/frontend/src/JSON/User.elm
@@ -2,13 +2,15 @@ module JSON.User exposing (..)
 
 import DefaultServices.Util as Util exposing (justValueOrNull)
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.User exposing (..)
 
 
 {-| `User` safe encoder.
-      - Does not encode password.
+
+  - Does not encode password.
+
 -}
 safeEncoder : User -> Encode.Value
 safeEncoder user =

--- a/frontend/src/JSON/ViewerRelevantHC.elm
+++ b/frontend/src/JSON/ViewerRelevantHC.elm
@@ -3,7 +3,7 @@ module JSON.ViewerRelevantHC exposing (..)
 import Array
 import DefaultServices.Util as Util
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.ViewerRelevantHC exposing (..)
 

--- a/frontend/src/Models/ApiError.elm
+++ b/frontend/src/Models/ApiError.elm
@@ -6,6 +6,7 @@ module Models.ApiError exposing (..)
 {-| An error from the backend converted to a union.
 
 NOTE: This must stay up to date with the backend, refer to types.ts to see backend errors.
+
 -}
 type ApiError
     = UnexpectedPayload

--- a/frontend/src/Models/Bigbit.elm
+++ b/frontend/src/Models/Bigbit.elm
@@ -69,7 +69,7 @@ isFSOpen (FS.FileStructure _ { openFS }) =
 -}
 toggleFS : FS.FileStructure { a | openFS : Bool } b c -> FS.FileStructure { a | openFS : Bool } b c
 toggleFS (FS.FileStructure tree fsMetadata) =
-    FS.FileStructure tree { fsMetadata | openFS = (not fsMetadata.openFS) }
+    FS.FileStructure tree { fsMetadata | openFS = not fsMetadata.openFS }
 
 
 {-| Closes the FS.

--- a/frontend/src/Models/ContentPointer.elm
+++ b/frontend/src/Models/ContentPointer.elm
@@ -1,9 +1,12 @@
 module Models.ContentPointer exposing (..)
 
+{-| -}
+
 
 {-| A way of pointing to specific content.
 
 Parallels to a `ContentPointer` from the backend.
+
 -}
 type alias ContentPointer =
     { contentType : ContentType
@@ -14,6 +17,7 @@ type alias ContentPointer =
 {-| The different `ContentType`s
 
 Parallels directly to `ContentType` enum on the backend.
+
 -}
 type ContentType
     = Snipbit

--- a/frontend/src/Models/Opinion.elm
+++ b/frontend/src/Models/Opinion.elm
@@ -7,6 +7,7 @@ import Models.Rating exposing (Rating)
 {-| An opinion on some specific content.
 
 Parallels to the backend `Opinion` but we don't include the `userID`
+
 -}
 type alias Opinion =
     { contentPointer : ContentPointer
@@ -17,6 +18,7 @@ type alias Opinion =
 {-| An opinion (or lack of opinion) on some specific content.
 
 Useful for rendering on the frontend where `Nothing` for the rating signafies that the user has no opinion.
+
 -}
 type alias PossibleOpinion =
     { contentPointer : ContentPointer

--- a/frontend/src/Models/QA.elm
+++ b/frontend/src/Models/QA.elm
@@ -147,6 +147,7 @@ type alias BigbitCodePointer =
 For keeping track of things like half-written questions, or new questions etc...
 
 NOTE: The state for each tidbit is saved separately so tidbit-states do not overwrite each other.
+
 -}
 type alias QAState codePointer =
     Dict.Dict TidbitID (TidbitQAState codePointer)
@@ -167,6 +168,7 @@ type alias BigbitQAState =
 {-| The QA state for a single tidbit.
 
 State includes creating new and editing: question / answers on questions / comment on answers / comment on questions.
+
 -}
 type alias TidbitQAState codePointer =
     { browsingCodePointer : Maybe codePointer
@@ -398,12 +400,14 @@ updateQuestion questionID questionUpdater qa =
 
 
 {-| Updates a [published] question in the QA, handles all required logic:
+
   - Upvoting/downvoting question
   - Possibly removing previous upvote/downvote
   - Updating upvote/downvote count
   - Resorting questions.
 
 NOTE: If `vote` is `Nothing`, means that the user was removing a vote (could be either upvote/downvote).
+
 -}
 rateQuestion : QuestionID -> Maybe Vote.Vote -> QA codePointer -> QA codePointer
 rateQuestion questionID vote =
@@ -411,7 +415,7 @@ rateQuestion questionID vote =
         updateQuestionUpvotesAndDownvotesForQA qa =
             updateQuestion questionID (updateVotes vote) qa
     in
-        updateQuestionUpvotesAndDownvotesForQA >> sortQuestions
+    updateQuestionUpvotesAndDownvotesForQA >> sortQuestions
 
 
 {-| Adds a `QuestionComment` to the [published] list of question comments.
@@ -449,12 +453,14 @@ sortQuestions qa =
 
 
 {-| Updates a [published] answer, handles:
-    - Upvoting/downvoting answer
-    - Possibly removing previous upvote/downvote
-    - Updating upvote/downvote count
-    - Resorting answers.
+
+  - Upvoting/downvoting answer
+  - Possibly removing previous upvote/downvote
+  - Updating upvote/downvote count
+  - Resorting answers.
 
 NOTE: If vote is `Nothing`, means the user was was removing a vote (could be either upvote/downvote).
+
 -}
 rateAnswer : AnswerID -> Maybe Vote.Vote -> QA codePointer -> QA codePointer
 rateAnswer answerID vote =
@@ -462,7 +468,7 @@ rateAnswer answerID vote =
         updateAnswerUpvotesAndDownvotesForQA qa =
             updateAnswer answerID (Just << updateVotes vote) qa
     in
-        updateAnswerUpvotesAndDownvotesForQA >> sortAnswers
+    updateAnswerUpvotesAndDownvotesForQA >> sortAnswers
 
 
 {-| Adds a `AnswerComment` to the [published] list of answer comments.
@@ -507,8 +513,10 @@ sortAnswers qa =
 
 
 {-| Updates a [published] question, handles:
-    - Pinning/unpinning question
-    - Resorting questions
+
+  - Pinning/unpinning question
+  - Resorting questions
+
 -}
 pinQuestion : QuestionID -> Bool -> QA codePointer -> QA codePointer
 pinQuestion questionID isPinned =
@@ -516,12 +524,14 @@ pinQuestion questionID isPinned =
         updatePin =
             updateQuestion questionID (\question -> { question | pinned = isPinned })
     in
-        updatePin >> sortQuestions
+    updatePin >> sortQuestions
 
 
 {-| Updates a [published] answer, handles:
-    - Pinning/unpinning answer
-    - Resorting answers
+
+  - Pinning/unpinning answer
+  - Resorting answers
+
 -}
 pinAnswer : AnswerID -> Bool -> QA codePointer -> QA codePointer
 pinAnswer answerID isPinned =
@@ -529,7 +539,7 @@ pinAnswer answerID isPinned =
         updatePin =
             updateAnswer answerID (\answer -> Just { answer | pinned = isPinned })
     in
-        updatePin >> sortAnswers
+    updatePin >> sortAnswers
 
 
 {-| Updates a [published] answer in the QA.
@@ -564,6 +574,7 @@ updateNewQuestion tidbitID newQuestionUpdater =
 {-| questionEdit updater, handles setting default tidbitQAState if needed.
 
 Updater has to handle case where no edit exits yet (hence `Maybe QuestionEdit...`).
+
 -}
 updateQuestionEdit :
     TidbitID
@@ -587,6 +598,7 @@ updateQuestionEdit tidbitID questionID questionEditUpdater =
 {-| newAnswer updater, handles setting default tidbitQAState if needed.
 
 Updater has to handle case where no new answer exists yet for that question (hence `Maybe NewAnswer...`).
+
 -}
 updateNewAnswer :
     TidbitID
@@ -609,10 +621,12 @@ updateNewAnswer tidbitID questionID newAnswerUpdater =
 
 
 {-| Sorts the RateableContent by:
-    - is pinned
-    - most upvotes
-    - least downvotes
-    - newest date
+
+  - is pinned
+  - most upvotes
+  - least downvotes
+  - newest date
+
 -}
 sortRateableContent : List (RateableContent x) -> List (RateableContent x)
 sortRateableContent =
@@ -627,6 +641,7 @@ sortRateableContent =
 {-| answerEdit updater, handles setting default tidbitQAState if needed.
 
 Updater has to handle case where no new answer edit exists (hence `Maybe AnswerEdit...`).
+
 -}
 updateAnswerEdit :
     TidbitID
@@ -685,6 +700,7 @@ updateAnswerCommentEdits tidbitID answerCommentEditsUpdater =
 {-| Delete all `answerCommentEdits` on a `qaState` pointing to non-existant comments.
 
 Handles setting default if no `tidbitQAState` exists.
+
 -}
 deleteOldAnswerCommentEdits : TidbitID -> List AnswerComment -> QAState codePointer -> QAState codePointer
 deleteOldAnswerCommentEdits tidbitID answerComments =
@@ -723,6 +739,7 @@ updateNewAnswerComments tidbitID newAnswerCommentsUpdater =
 {-| Set's a single `newQuestionComment`, handles setting default if no `tidbitQAState` exists.
 
 If you'd like to delete the new question comment, pass in `Nothing` for the `commentText`.
+
 -}
 setNewQuestionComment : TidbitID -> QuestionID -> Maybe CommentText -> QAState codePointer -> QAState codePointer
 setNewQuestionComment tidbitID questionID commentText =
@@ -760,6 +777,7 @@ setTidbitQAState tidbitID tidbitQAStateUpdater qaState =
 {-| Helper for updating the vote count.
 
 NOTE: If `vote` is `Nothing` that means that the user was removing his vote.
+
 -}
 updateVotes : Maybe Vote.Vote -> ContentWithVotes x -> ContentWithVotes x
 updateVotes vote contentWithVotes =
@@ -774,7 +792,7 @@ updateVotes vote contentWithVotes =
 
                 _ ->
                     if Tuple.first contentWithVotes.upvotes then
-                        ( False, (flip (-)) 1 <| Tuple.second contentWithVotes.upvotes )
+                        ( False, flip (-) 1 <| Tuple.second contentWithVotes.upvotes )
                     else
                         contentWithVotes.upvotes
         , downvotes =
@@ -787,7 +805,7 @@ updateVotes vote contentWithVotes =
 
                 _ ->
                     if Tuple.first contentWithVotes.downvotes then
-                        ( False, (flip (-)) 1 <| Tuple.second contentWithVotes.downvotes )
+                        ( False, flip (-) 1 <| Tuple.second contentWithVotes.downvotes )
                     else
                         contentWithVotes.downvotes
     }
@@ -797,8 +815,8 @@ updateVotes vote contentWithVotes =
 -}
 isBigbitCodePointerOverlap : BigbitCodePointer -> BigbitCodePointer -> Bool
 isBigbitCodePointerOverlap codePointer1 codePointer2 =
-    (FS.isSameFilePath codePointer1.file codePointer2.file)
-        && (Range.overlappingRanges codePointer1.range codePointer2.range)
+    FS.isSameFilePath codePointer1.file codePointer2.file
+        && Range.overlappingRanges codePointer1.range codePointer2.range
 
 
 {-| The default state for `TidbitQAState`.

--- a/frontend/src/Models/Range.elm
+++ b/frontend/src/Models/Range.elm
@@ -72,11 +72,11 @@ newValidRange range newCode =
         ( newEndRow, newEndCol ) =
             getNewColAndRow range.endRow range.endCol
     in
-        { startRow = newStartRow
-        , startCol = newStartCol
-        , endRow = newEndRow
-        , endCol = newEndCol
-        }
+    { startRow = newStartRow
+    , startCol = newStartCol
+    , endRow = newEndRow
+    , endCol = newEndCol
+    }
 
 
 {-| Returns true if `range1` is before `range2` and has absolutey no overlap.
@@ -119,7 +119,8 @@ from the left treating the code as one long string of characters.
 NOTE: We do count newlines as characters.
 
 WARNING: Assumes the code is valid for the range, does not check and will produce an incorrect result if the range is
-         not valid for the given code.
+not valid for the given code.
+
 -}
 toOneDimensionalCoordinates : String -> Range -> ( Int, Int )
 toOneDimensionalCoordinates code range =
@@ -136,17 +137,18 @@ toOneDimensionalCoordinates code range =
             if currentRow == row then
                 currentAcc + col
             else
-                startCounting ( row, col ) (currentRow + 1) (1 + currentAcc + (lengthOfRow currentRow))
+                startCounting ( row, col ) (currentRow + 1) (1 + currentAcc + lengthOfRow currentRow)
     in
-        ( startCounting ( range.startRow, range.startCol ) 0 0
-        , startCounting ( range.endRow, range.endCol ) 0 0
-        )
+    ( startCounting ( range.startRow, range.startCol ) 0 0
+    , startCounting ( range.endRow, range.endCol ) 0 0
+    )
 
 
 {-| Given some code and 1 dimensional coordinates, returns the range for those coordinates.
 
 WARNING: Assumes the code is valid for the coordinates, does not check and will produce an incorrect result if the given
-         coordinates are invalid.
+coordinates are invalid.
+
 -}
 fromOneDimensionalCoordinates : String -> ( Int, Int ) -> Range
 fromOneDimensionalCoordinates code ( start, end ) =
@@ -171,7 +173,7 @@ fromOneDimensionalCoordinates code ( start, end ) =
                     Array.get row codeAsArray
                         |> Util.maybeMapWithDefault String.length 0
             in
-                ( row, col )
+            ( row, col )
 
         ( startRow, startCol ) =
             getRowAndColForSubString codeBeforeFirstCoordinate
@@ -179,11 +181,11 @@ fromOneDimensionalCoordinates code ( start, end ) =
         ( endRow, endCol ) =
             getRowAndColForSubString codeBeforeSecondCoordinate
     in
-        { startRow = startRow
-        , startCol = startCol
-        , endRow = endRow
-        , endCol = endCol
-        }
+    { startRow = startRow
+    , startCol = startCol
+    , endRow = endRow
+    , endCol = endCol
+    }
 
 
 {-| Shifts the coordinates by `shiftAmount`.
@@ -196,8 +198,9 @@ shiftCoordinates shiftAmount ( start, end ) =
 {-| Gets the new range after a change has been made in the editor.
 
 NOTE: This originally was a massive pain in the ass, but a shift in the approach has made it much simpler, we think
-      about the domain in 1 dimension, do the transformations, and only at the end convert back to the 2 dimensional
-      matrix. This avoids a lot of nasty code.
+about the domain in 1 dimension, do the transformations, and only at the end convert back to the 2 dimensional
+matrix. This avoids a lot of nasty code.
+
 -}
 getNewRangeAfterDelta : String -> String -> String -> Range -> Range -> Range
 getNewRangeAfterDelta oldCode newCode action deltaRange selectedRange =
@@ -205,52 +208,52 @@ getNewRangeAfterDelta oldCode newCode action deltaRange selectedRange =
         (( selectedStartCoordinate, selectedEndCoordinate ) as selectedCoordinates) =
             toOneDimensionalCoordinates oldCode selectedRange
     in
-        case action of
-            "insert" ->
-                let
-                    -- With insertion, we want to get the 1D coordinates against the new code.
-                    ( deltaStartCoordinate, deltaEndCoordinate ) =
-                        toOneDimensionalCoordinates newCode deltaRange
+    case action of
+        "insert" ->
+            let
+                -- With insertion, we want to get the 1D coordinates against the new code.
+                ( deltaStartCoordinate, deltaEndCoordinate ) =
+                    toOneDimensionalCoordinates newCode deltaRange
 
-                    deltaLength =
-                        deltaEndCoordinate - deltaStartCoordinate
-                in
-                    if deltaStartCoordinate <= selectedStartCoordinate then
-                        fromOneDimensionalCoordinates newCode (shiftCoordinates deltaLength selectedCoordinates)
-                    else if deltaStartCoordinate < selectedEndCoordinate then
-                        fromOneDimensionalCoordinates newCode ( selectedStartCoordinate, selectedEndCoordinate + deltaLength )
-                    else
-                        selectedRange
-
-            "remove" ->
-                let
-                    -- With removal, we want to get the 1D coordinates against the old code, because that's the code we
-                    -- are erasing.
-                    ( deltaStartCoordinate, deltaEndCoordinate ) =
-                        toOneDimensionalCoordinates oldCode deltaRange
-
-                    deltaLength =
-                        deltaEndCoordinate - deltaStartCoordinate
-                in
-                    if deltaEndCoordinate <= selectedStartCoordinate then
-                        fromOneDimensionalCoordinates newCode (shiftCoordinates (-1 * deltaLength) selectedCoordinates)
-                    else if deltaEndCoordinate <= selectedEndCoordinate then
-                        fromOneDimensionalCoordinates
-                            newCode
-                            ( Basics.min selectedStartCoordinate deltaStartCoordinate
-                            , selectedEndCoordinate - deltaLength
-                            )
-                    else
-                        fromOneDimensionalCoordinates
-                            newCode
-                            ( Basics.min selectedStartCoordinate deltaStartCoordinate
-                            , Basics.min selectedEndCoordinate deltaStartCoordinate
-                            )
-
-            -- This will never happen, ACE actions are limited to "insert" and "remove", otherwise ACE errors internally
-            -- and never sends it.
-            _ ->
+                deltaLength =
+                    deltaEndCoordinate - deltaStartCoordinate
+            in
+            if deltaStartCoordinate <= selectedStartCoordinate then
+                fromOneDimensionalCoordinates newCode (shiftCoordinates deltaLength selectedCoordinates)
+            else if deltaStartCoordinate < selectedEndCoordinate then
+                fromOneDimensionalCoordinates newCode ( selectedStartCoordinate, selectedEndCoordinate + deltaLength )
+            else
                 selectedRange
+
+        "remove" ->
+            let
+                -- With removal, we want to get the 1D coordinates against the old code, because that's the code we
+                -- are erasing.
+                ( deltaStartCoordinate, deltaEndCoordinate ) =
+                    toOneDimensionalCoordinates oldCode deltaRange
+
+                deltaLength =
+                    deltaEndCoordinate - deltaStartCoordinate
+            in
+            if deltaEndCoordinate <= selectedStartCoordinate then
+                fromOneDimensionalCoordinates newCode (shiftCoordinates (-1 * deltaLength) selectedCoordinates)
+            else if deltaEndCoordinate <= selectedEndCoordinate then
+                fromOneDimensionalCoordinates
+                    newCode
+                    ( Basics.min selectedStartCoordinate deltaStartCoordinate
+                    , selectedEndCoordinate - deltaLength
+                    )
+            else
+                fromOneDimensionalCoordinates
+                    newCode
+                    ( Basics.min selectedStartCoordinate deltaStartCoordinate
+                    , Basics.min selectedEndCoordinate deltaStartCoordinate
+                    )
+
+        -- This will never happen, ACE actions are limited to "insert" and "remove", otherwise ACE errors internally
+        -- and never sends it.
+        _ ->
+            selectedRange
 
 
 {-| An empty range with every point on the origin.

--- a/frontend/src/Models/Rating.elm
+++ b/frontend/src/Models/Rating.elm
@@ -1,9 +1,12 @@
 module Models.Rating exposing (..)
 
+{-| -}
+
 
 {-| Represents how a user feels about specific content.
 
 Parallels to the `Rating` enum on the backend.
+
 -}
 type Rating
     = Like

--- a/frontend/src/Models/RequestTracker.elm
+++ b/frontend/src/Models/RequestTracker.elm
@@ -14,6 +14,7 @@ import ProjectTypeAliases exposing (..)
 NOTE: We will be `toString`ing these and using them as they key. So if you add parameters to the constructors, passing
 in different parameters will result in different requests being tracked. Only use parameters if you specifically want
 to track certain versions of a request differently.
+
 -}
 type TrackedRequest
     = LoginOrRegister
@@ -59,7 +60,7 @@ startRequest trackedRequest =
         (\maybeCount ->
             maybeCount
                 ?> 0
-                |> ((+) 1)
+                |> (+) 1
                 |> Just
         )
 

--- a/frontend/src/Models/Route.elm
+++ b/frontend/src/Models/Route.elm
@@ -9,12 +9,13 @@ import Models.Bigbit as Bigbit
 import Models.QA as QA
 import Navigation
 import ProjectTypeAliases exposing (..)
-import UrlParser exposing (Parser, s, (</>), (<?>), oneOf, map, top, int, string, stringParam)
+import UrlParser exposing ((</>), (<?>), Parser, int, map, oneOf, s, string, stringParam, top)
 
 
 {-| All of the app routes.
 
 NOTE: When creating routes, use type aliases to make sure that the purpose of each parameter is clear (eg. StoryID).
+
 -}
 type Route
     = BrowsePage
@@ -271,57 +272,57 @@ matchers =
         login =
             s "login"
     in
-        oneOf
-            [ map BrowsePage top
-            , map ViewSnipbitIntroductionPage viewSnipbitIntroduction
-            , map ViewSnipbitConclusionPage viewSnipbitConclusion
-            , map ViewSnipbitFramePage viewSnipbitFrame
-            , map ViewSnipbitQuestionsPage viewSnipbitQuestionsPage
-            , map ViewSnipbitQuestionPage viewSnipbitQuestionPage
-            , map ViewSnipbitAnswersPage viewSnipbitAnswersPage
-            , map ViewSnipbitAnswerPage viewSnipbitAnswerPage
-            , map ViewSnipbitQuestionCommentsPage viewSnipbitQuestionCommentsPage
-            , map ViewSnipbitAnswerCommentsPage viewSnipbitAnswerCommentsPage
-            , map ViewSnipbitAskQuestion viewSnipbitAskQuestion
-            , map ViewSnipbitAnswerQuestion viewSnipbitAnswerQuestion
-            , map ViewSnipbitEditQuestion viewSnipbitEditQuestion
-            , map ViewSnipbitEditAnswer viewSnipbitEditAnswer
-            , map ViewBigbitIntroductionPage viewBigbitIntroduction
-            , map ViewBigbitFramePage viewBigbitFrame
-            , map ViewBigbitConclusionPage viewBigbitConclusion
-            , map ViewBigbitQuestionsPage viewBigbitQuestionsPage
-            , map ViewBigbitQuestionPage viewBigbitQuestionPage
-            , map ViewBigbitAnswersPage viewBigbitAnswersPage
-            , map ViewBigbitAnswerPage viewBigbitAnswerPage
-            , map ViewBigbitQuestionCommentsPage viewBigbitQuestionCommentsPage
-            , map ViewBigbitAnswerCommentsPage viewBigbitAnswerCommentsPage
-            , map ViewBigbitAskQuestion viewBigbitAskQuestion
-            , map ViewBigbitEditQuestion viewBigbitEditQuestion
-            , map ViewBigbitAnswerQuestion viewBigbitAnswerQuestion
-            , map ViewBigbitEditAnswer viewBigbitEditAnswer
-            , map ViewStoryPage viewStory
-            , map CreatePage create
-            , map CreateSnipbitNamePage createSnipbitName
-            , map CreateSnipbitDescriptionPage createSnipbitDescription
-            , map CreateSnipbitLanguagePage createSnipbitLanguage
-            , map CreateSnipbitTagsPage createSnipbitTags
-            , map CreateSnipbitCodeIntroductionPage createSnipbitCodeIntroduction
-            , map CreateSnipbitCodeFramePage createSnipbitCodeFrame
-            , map CreateSnipbitCodeConclusionPage createSnipbitCodeConclusion
-            , map CreateBigbitNamePage createBigbitName
-            , map CreateBigbitDescriptionPage createBigbitDescription
-            , map CreateBigbitTagsPage createBigbitTags
-            , map CreateBigbitCodeIntroductionPage createBigbitCodeIntroduction
-            , map CreateBigbitCodeFramePage createBigbitCodeFrame
-            , map CreateBigbitCodeConclusionPage createBigbitCodeConclusion
-            , map CreateStoryNamePage createStoryName
-            , map CreateStoryDescriptionPage createStoryDescription
-            , map CreateStoryTagsPage createStoryTags
-            , map DevelopStoryPage developStory
-            , map ProfilePage profile
-            , map RegisterPage register
-            , map LoginPage login
-            ]
+    oneOf
+        [ map BrowsePage top
+        , map ViewSnipbitIntroductionPage viewSnipbitIntroduction
+        , map ViewSnipbitConclusionPage viewSnipbitConclusion
+        , map ViewSnipbitFramePage viewSnipbitFrame
+        , map ViewSnipbitQuestionsPage viewSnipbitQuestionsPage
+        , map ViewSnipbitQuestionPage viewSnipbitQuestionPage
+        , map ViewSnipbitAnswersPage viewSnipbitAnswersPage
+        , map ViewSnipbitAnswerPage viewSnipbitAnswerPage
+        , map ViewSnipbitQuestionCommentsPage viewSnipbitQuestionCommentsPage
+        , map ViewSnipbitAnswerCommentsPage viewSnipbitAnswerCommentsPage
+        , map ViewSnipbitAskQuestion viewSnipbitAskQuestion
+        , map ViewSnipbitAnswerQuestion viewSnipbitAnswerQuestion
+        , map ViewSnipbitEditQuestion viewSnipbitEditQuestion
+        , map ViewSnipbitEditAnswer viewSnipbitEditAnswer
+        , map ViewBigbitIntroductionPage viewBigbitIntroduction
+        , map ViewBigbitFramePage viewBigbitFrame
+        , map ViewBigbitConclusionPage viewBigbitConclusion
+        , map ViewBigbitQuestionsPage viewBigbitQuestionsPage
+        , map ViewBigbitQuestionPage viewBigbitQuestionPage
+        , map ViewBigbitAnswersPage viewBigbitAnswersPage
+        , map ViewBigbitAnswerPage viewBigbitAnswerPage
+        , map ViewBigbitQuestionCommentsPage viewBigbitQuestionCommentsPage
+        , map ViewBigbitAnswerCommentsPage viewBigbitAnswerCommentsPage
+        , map ViewBigbitAskQuestion viewBigbitAskQuestion
+        , map ViewBigbitEditQuestion viewBigbitEditQuestion
+        , map ViewBigbitAnswerQuestion viewBigbitAnswerQuestion
+        , map ViewBigbitEditAnswer viewBigbitEditAnswer
+        , map ViewStoryPage viewStory
+        , map CreatePage create
+        , map CreateSnipbitNamePage createSnipbitName
+        , map CreateSnipbitDescriptionPage createSnipbitDescription
+        , map CreateSnipbitLanguagePage createSnipbitLanguage
+        , map CreateSnipbitTagsPage createSnipbitTags
+        , map CreateSnipbitCodeIntroductionPage createSnipbitCodeIntroduction
+        , map CreateSnipbitCodeFramePage createSnipbitCodeFrame
+        , map CreateSnipbitCodeConclusionPage createSnipbitCodeConclusion
+        , map CreateBigbitNamePage createBigbitName
+        , map CreateBigbitDescriptionPage createBigbitDescription
+        , map CreateBigbitTagsPage createBigbitTags
+        , map CreateBigbitCodeIntroductionPage createBigbitCodeIntroduction
+        , map CreateBigbitCodeFramePage createBigbitCodeFrame
+        , map CreateBigbitCodeConclusionPage createBigbitCodeConclusion
+        , map CreateStoryNamePage createStoryName
+        , map CreateStoryDescriptionPage createStoryDescription
+        , map CreateStoryTagsPage createStoryTags
+        , map DevelopStoryPage developStory
+        , map ProfilePage profile
+        , map RegisterPage register
+        , map LoginPage login
+        ]
 
 
 {-| Returns `True` iff the route requires authentication.
@@ -402,7 +403,8 @@ routeRequiresAuth route =
 {-| Returns `True` iff the route requires that the user not be authenticated.
 
 NOTE: This is NOT the same as `not routeRequiresAuth` as there are routes that the user can access both logged-in and
-      logged-out, these are specifically the routes that you must be logged-out to access.
+logged-out, these are specifically the routes that you must be logged-out to access.
+
 -}
 routeRequiresNotAuth : Route -> Bool
 routeRequiresNotAuth route =
@@ -436,286 +438,287 @@ defaultUnauthRoute =
 toHashUrl : Route -> String
 toHashUrl route =
     "#"
-        ++ case route of
-            BrowsePage ->
-                ""
+        ++ (case route of
+                BrowsePage ->
+                    ""
 
-            CreatePage ->
-                "create"
+                CreatePage ->
+                    "create"
 
-            ViewSnipbitIntroductionPage qpStoryID mongoID ->
-                "view/snipbit/"
-                    ++ mongoID
-                    ++ "/introduction"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitIntroductionPage qpStoryID mongoID ->
+                    "view/snipbit/"
+                        ++ mongoID
+                        ++ "/introduction"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitConclusionPage qpStoryID mongoID ->
-                "view/snipbit/"
-                    ++ mongoID
-                    ++ "/conclusion"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitConclusionPage qpStoryID mongoID ->
+                    "view/snipbit/"
+                        ++ mongoID
+                        ++ "/conclusion"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitFramePage qpStoryID mongoID frameNumber ->
-                "view/snipbit/"
-                    ++ mongoID
-                    ++ "/frame/"
-                    ++ (toString frameNumber)
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitFramePage qpStoryID mongoID frameNumber ->
+                    "view/snipbit/"
+                        ++ mongoID
+                        ++ "/frame/"
+                        ++ toString frameNumber
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitQuestionsPage qpStoryID snipbitID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/questions"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitQuestionsPage qpStoryID snipbitID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/questions"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitQuestionPage qpStoryID qpTouringQuestions snipbitID questionID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewSnipbitQuestionPage qpStoryID qpTouringQuestions snipbitID questionID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewSnipbitAnswersPage qpStoryID qpTouringQuestions snipbitID questionID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ "/answers"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewSnipbitAnswersPage qpStoryID qpTouringQuestions snipbitID questionID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ "/answers"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewSnipbitAnswerPage qpStoryID qpTouringQuestions snipbitID answerID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/answer/"
-                    ++ answerID
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewSnipbitAnswerPage qpStoryID qpTouringQuestions snipbitID answerID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/answer/"
+                        ++ answerID
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewSnipbitQuestionCommentsPage qpStoryID qpTouringQuestions snipbitID questionID qpCommentID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ "/comments"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID )
-                        , ( "commentID", qpCommentID )
-                        , ( "touringQuestions", qpTouringQuestions )
-                        ]
+                ViewSnipbitQuestionCommentsPage qpStoryID qpTouringQuestions snipbitID questionID qpCommentID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ "/comments"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID )
+                            , ( "commentID", qpCommentID )
+                            , ( "touringQuestions", qpTouringQuestions )
+                            ]
 
-            ViewSnipbitAnswerCommentsPage qpStoryID qpTouringQuestions snipbitID answerID qpCommentID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/answer/"
-                    ++ answerID
-                    ++ "/comments"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID )
-                        , ( "commentID", qpCommentID )
-                        , ( "touringQuestions", qpTouringQuestions )
-                        ]
+                ViewSnipbitAnswerCommentsPage qpStoryID qpTouringQuestions snipbitID answerID qpCommentID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/answer/"
+                        ++ answerID
+                        ++ "/comments"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID )
+                            , ( "commentID", qpCommentID )
+                            , ( "touringQuestions", qpTouringQuestions )
+                            ]
 
-            ViewSnipbitAskQuestion qpStoryID snipbitID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/askQuestion"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitAskQuestion qpStoryID snipbitID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/askQuestion"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitAnswerQuestion qpStoryID snipbitID questionID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/answerQuestion/"
-                    ++ questionID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitAnswerQuestion qpStoryID snipbitID questionID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/answerQuestion/"
+                        ++ questionID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitEditQuestion qpStoryID snipbitID questionID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/editQuestion/"
-                    ++ questionID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitEditQuestion qpStoryID snipbitID questionID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/editQuestion/"
+                        ++ questionID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewSnipbitEditAnswer qpStoryID snipbitID answerID ->
-                "view/snipbit/"
-                    ++ snipbitID
-                    ++ "/editAnswer/"
-                    ++ answerID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewSnipbitEditAnswer qpStoryID snipbitID answerID ->
+                    "view/snipbit/"
+                        ++ snipbitID
+                        ++ "/editAnswer/"
+                        ++ answerID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitIntroductionPage qpStoryID mongoID qpFile ->
-                "view/bigbit/"
-                    ++ mongoID
-                    ++ "/introduction/"
-                    ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
+                ViewBigbitIntroductionPage qpStoryID mongoID qpFile ->
+                    "view/bigbit/"
+                        ++ mongoID
+                        ++ "/introduction/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitConclusionPage qpStoryID mongoID qpFile ->
-                "view/bigbit/"
-                    ++ mongoID
-                    ++ "/conclusion/"
-                    ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
+                ViewBigbitConclusionPage qpStoryID mongoID qpFile ->
+                    "view/bigbit/"
+                        ++ mongoID
+                        ++ "/conclusion/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitFramePage qpStoryID mongoID frameNumber qpFile ->
-                "view/bigbit/"
-                    ++ mongoID
-                    ++ "/frame/"
-                    ++ (toString frameNumber)
-                    ++ "/"
-                    ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
+                ViewBigbitFramePage qpStoryID mongoID frameNumber qpFile ->
+                    "view/bigbit/"
+                        ++ mongoID
+                        ++ "/frame/"
+                        ++ toString frameNumber
+                        ++ "/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ), ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitQuestionsPage qpStoryID bigbitID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/questions"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewBigbitQuestionsPage qpStoryID bigbitID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/questions"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitQuestionPage qpStoryID qpTouringQuestions bigbitID questionID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewBigbitQuestionPage qpStoryID qpTouringQuestions bigbitID questionID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewBigbitAnswersPage qpStoryID qpTouringQuestions bigbitID questionID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ "/answers"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewBigbitAnswersPage qpStoryID qpTouringQuestions bigbitID questionID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ "/answers"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewBigbitAnswerPage qpStoryID qpTouringQuestions bigbitID answerID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/answer/"
-                    ++ answerID
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
+                ViewBigbitAnswerPage qpStoryID qpTouringQuestions bigbitID answerID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/answer/"
+                        ++ answerID
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID ), ( "touringQuestions", qpTouringQuestions ) ]
 
-            ViewBigbitQuestionCommentsPage qpStoryID qpTouringQuestions bigbitID questionID qpCommentID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/question/"
-                    ++ questionID
-                    ++ "/comments"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID )
-                        , ( "touringQuestions", qpTouringQuestions )
-                        , ( "commentID", qpCommentID )
-                        ]
+                ViewBigbitQuestionCommentsPage qpStoryID qpTouringQuestions bigbitID questionID qpCommentID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/question/"
+                        ++ questionID
+                        ++ "/comments"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID )
+                            , ( "touringQuestions", qpTouringQuestions )
+                            , ( "commentID", qpCommentID )
+                            ]
 
-            ViewBigbitAnswerCommentsPage qpStoryID qpTouringQuestions bigbitID answerID qpCommentID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/answer/"
-                    ++ answerID
-                    ++ "/comments"
-                    ++ Util.queryParamsToString
-                        [ ( "fromStory", qpStoryID )
-                        , ( "touringQuestions", qpTouringQuestions )
-                        , ( "commentID", qpCommentID )
-                        ]
+                ViewBigbitAnswerCommentsPage qpStoryID qpTouringQuestions bigbitID answerID qpCommentID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/answer/"
+                        ++ answerID
+                        ++ "/comments"
+                        ++ Util.queryParamsToString
+                            [ ( "fromStory", qpStoryID )
+                            , ( "touringQuestions", qpTouringQuestions )
+                            , ( "commentID", qpCommentID )
+                            ]
 
-            ViewBigbitAskQuestion qpStoryID bigbitID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/askQuestion"
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewBigbitAskQuestion qpStoryID bigbitID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/askQuestion"
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitEditQuestion qpStoryID bigbitID questionID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/editQuestion/"
-                    ++ questionID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewBigbitEditQuestion qpStoryID bigbitID questionID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/editQuestion/"
+                        ++ questionID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitAnswerQuestion qpStoryID bigbitID questionID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/answerQuestion/"
-                    ++ questionID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewBigbitAnswerQuestion qpStoryID bigbitID questionID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/answerQuestion/"
+                        ++ questionID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewBigbitEditAnswer qpStoryID bigbitID answerID ->
-                "view/bigbit/"
-                    ++ bigbitID
-                    ++ "/editAnswer/"
-                    ++ answerID
-                    ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
+                ViewBigbitEditAnswer qpStoryID bigbitID answerID ->
+                    "view/bigbit/"
+                        ++ bigbitID
+                        ++ "/editAnswer/"
+                        ++ answerID
+                        ++ Util.queryParamsToString [ ( "fromStory", qpStoryID ) ]
 
-            ViewStoryPage mongoID ->
-                "view/story/" ++ mongoID
+                ViewStoryPage mongoID ->
+                    "view/story/" ++ mongoID
 
-            CreateSnipbitNamePage ->
-                "create/snipbit/name"
+                CreateSnipbitNamePage ->
+                    "create/snipbit/name"
 
-            CreateSnipbitDescriptionPage ->
-                "create/snipbit/description"
+                CreateSnipbitDescriptionPage ->
+                    "create/snipbit/description"
 
-            CreateSnipbitLanguagePage ->
-                "create/snipbit/language"
+                CreateSnipbitLanguagePage ->
+                    "create/snipbit/language"
 
-            CreateSnipbitTagsPage ->
-                "create/snipbit/tags"
+                CreateSnipbitTagsPage ->
+                    "create/snipbit/tags"
 
-            CreateSnipbitCodeIntroductionPage ->
-                "create/snipbit/code/introduction"
+                CreateSnipbitCodeIntroductionPage ->
+                    "create/snipbit/code/introduction"
 
-            CreateSnipbitCodeFramePage frameNumber ->
-                "create/snipbit/code/frame/" ++ (toString frameNumber)
+                CreateSnipbitCodeFramePage frameNumber ->
+                    "create/snipbit/code/frame/" ++ toString frameNumber
 
-            CreateSnipbitCodeConclusionPage ->
-                "create/snipbit/code/conclusion"
+                CreateSnipbitCodeConclusionPage ->
+                    "create/snipbit/code/conclusion"
 
-            CreateBigbitNamePage ->
-                "create/bigbit/name"
+                CreateBigbitNamePage ->
+                    "create/bigbit/name"
 
-            CreateBigbitDescriptionPage ->
-                "create/bigbit/description"
+                CreateBigbitDescriptionPage ->
+                    "create/bigbit/description"
 
-            CreateBigbitTagsPage ->
-                "create/bigbit/tags"
+                CreateBigbitTagsPage ->
+                    "create/bigbit/tags"
 
-            CreateBigbitCodeIntroductionPage qpFile ->
-                "create/bigbit/code/introduction/"
-                    ++ (Util.queryParamsToString [ ( "file", qpFile ) ])
+                CreateBigbitCodeIntroductionPage qpFile ->
+                    "create/bigbit/code/introduction/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ) ]
 
-            CreateBigbitCodeFramePage frameNumber qpFile ->
-                "create/bigbit/code/frame/"
-                    ++ (toString frameNumber)
-                    ++ "/"
-                    ++ (Util.queryParamsToString [ ( "file", qpFile ) ])
+                CreateBigbitCodeFramePage frameNumber qpFile ->
+                    "create/bigbit/code/frame/"
+                        ++ toString frameNumber
+                        ++ "/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ) ]
 
-            CreateBigbitCodeConclusionPage qpFile ->
-                "create/bigbit/code/conclusion/"
-                    ++ (Util.queryParamsToString [ ( "file", qpFile ) ])
+                CreateBigbitCodeConclusionPage qpFile ->
+                    "create/bigbit/code/conclusion/"
+                        ++ Util.queryParamsToString [ ( "file", qpFile ) ]
 
-            CreateStoryNamePage qpStory ->
-                "create/story/name"
-                    ++ (Util.queryParamsToString [ ( "editingStory", qpStory ) ])
+                CreateStoryNamePage qpStory ->
+                    "create/story/name"
+                        ++ Util.queryParamsToString [ ( "editingStory", qpStory ) ]
 
-            CreateStoryDescriptionPage qpStory ->
-                "create/story/description"
-                    ++ (Util.queryParamsToString [ ( "editingStory", qpStory ) ])
+                CreateStoryDescriptionPage qpStory ->
+                    "create/story/description"
+                        ++ Util.queryParamsToString [ ( "editingStory", qpStory ) ]
 
-            CreateStoryTagsPage qpStory ->
-                "create/story/tags"
-                    ++ (Util.queryParamsToString [ ( "editingStory", qpStory ) ])
+                CreateStoryTagsPage qpStory ->
+                    "create/story/tags"
+                        ++ Util.queryParamsToString [ ( "editingStory", qpStory ) ]
 
-            DevelopStoryPage storyID ->
-                "develop/story/" ++ storyID
+                DevelopStoryPage storyID ->
+                    "develop/story/" ++ storyID
 
-            ProfilePage ->
-                "profile"
+                ProfilePage ->
+                    "profile"
 
-            LoginPage ->
-                "login"
+                LoginPage ->
+                    "login"
 
-            RegisterPage ->
-                "register"
+                RegisterPage ->
+                    "register"
+           )
 
 
 {-| Attempts to parse a location into a route.
@@ -737,10 +740,10 @@ parseLocation location =
                         |> String.join "?"
                         |> String.append "?"
             in
-                { location | hash = hash, search = search }
+            { location | hash = hash, search = search }
     in
-        fixLocationHashQuery location
-            |> UrlParser.parseHash matchers
+    fixLocationHashQuery location
+        |> UrlParser.parseHash matchers
 
 
 {-| Navigates to a given route.
@@ -757,7 +760,7 @@ modifyTo route =
     Navigation.modifyUrl <| toHashUrl <| route
 
 
-{-| For routes that have a file path query paramter, will  navigate to the same URL but with the file path added as a
+{-| For routes that have a file path query paramter, will navigate to the same URL but with the file path added as a
 query param, otheriwse will do nothing.
 -}
 navigateToSameUrlWithFilePath : Maybe FS.Path -> Route -> Cmd msg
@@ -983,69 +986,69 @@ viewBigbitPageCurrentActiveFile route bigbit maybeQA qaState =
                 ||> .codePointer
                 ||> .file
     in
-        case route of
-            ViewBigbitIntroductionPage _ _ maybePath ->
+    case route of
+        ViewBigbitIntroductionPage _ _ maybePath ->
+            maybePath
+
+        ViewBigbitFramePage _ _ frameNumber maybePath ->
+            if Util.isNotNothing maybePath then
                 maybePath
-
-            ViewBigbitFramePage _ _ frameNumber maybePath ->
-                if Util.isNotNothing maybePath then
-                    maybePath
-                else
-                    Array.get (frameNumber - 1) bigbit.highlightedComments
-                        ||> .file
-
-            ViewBigbitConclusionPage _ _ maybePath ->
-                maybePath
-
-            ViewBigbitQuestionsPage _ bigbitID ->
-                qaState
-                    |> QA.getBrowseCodePointer bigbitID
+            else
+                Array.get (frameNumber - 1) bigbit.highlightedComments
                     ||> .file
 
-            ViewBigbitQuestionPage _ _ _ questionID ->
-                getActiveFileBasedOnQuestionID questionID
+        ViewBigbitConclusionPage _ _ maybePath ->
+            maybePath
 
-            ViewBigbitAnswersPage _ _ _ questionID ->
-                getActiveFileBasedOnQuestionID questionID
+        ViewBigbitQuestionsPage _ bigbitID ->
+            qaState
+                |> QA.getBrowseCodePointer bigbitID
+                ||> .file
 
-            ViewBigbitAnswerPage _ _ _ answerID ->
-                getActiveFileBasedOnAnswerID answerID
+        ViewBigbitQuestionPage _ _ _ questionID ->
+            getActiveFileBasedOnQuestionID questionID
 
-            ViewBigbitQuestionCommentsPage _ _ _ questionID _ ->
-                getActiveFileBasedOnQuestionID questionID
+        ViewBigbitAnswersPage _ _ _ questionID ->
+            getActiveFileBasedOnQuestionID questionID
 
-            ViewBigbitAnswerCommentsPage _ _ _ answerID _ ->
-                getActiveFileBasedOnAnswerID answerID
+        ViewBigbitAnswerPage _ _ _ answerID ->
+            getActiveFileBasedOnAnswerID answerID
 
-            ViewBigbitAskQuestion _ bigbitID ->
-                qaState
-                    |> QA.getNewQuestion bigbitID
-                    |||> .codePointer
-                    ||> .file
+        ViewBigbitQuestionCommentsPage _ _ _ questionID _ ->
+            getActiveFileBasedOnQuestionID questionID
 
-            ViewBigbitEditQuestion _ bigbitID questionID ->
-                qaState
-                    |> QA.getQuestionEdit bigbitID questionID
-                    ||> .codePointer
-                    ||> Editable.getBuffer
-                    ||> .file
-                    |> (\maybeFileFromEdit ->
-                            case maybeFileFromEdit of
-                                Nothing ->
-                                    getActiveFileBasedOnQuestionID questionID
+        ViewBigbitAnswerCommentsPage _ _ _ answerID _ ->
+            getActiveFileBasedOnAnswerID answerID
 
-                                Just fileFromEdit ->
-                                    Just fileFromEdit
-                       )
+        ViewBigbitAskQuestion _ bigbitID ->
+            qaState
+                |> QA.getNewQuestion bigbitID
+                |||> .codePointer
+                ||> .file
 
-            ViewBigbitAnswerQuestion _ _ questionID ->
-                getActiveFileBasedOnQuestionID questionID
+        ViewBigbitEditQuestion _ bigbitID questionID ->
+            qaState
+                |> QA.getQuestionEdit bigbitID questionID
+                ||> .codePointer
+                ||> Editable.getBuffer
+                ||> .file
+                |> (\maybeFileFromEdit ->
+                        case maybeFileFromEdit of
+                            Nothing ->
+                                getActiveFileBasedOnQuestionID questionID
 
-            ViewBigbitEditAnswer _ _ answerID ->
-                getActiveFileBasedOnAnswerID answerID
+                            Just fileFromEdit ->
+                                Just fileFromEdit
+                   )
 
-            _ ->
-                Nothing
+        ViewBigbitAnswerQuestion _ _ questionID ->
+            getActiveFileBasedOnQuestionID questionID
+
+        ViewBigbitEditAnswer _ _ answerID ->
+            getActiveFileBasedOnAnswerID answerID
+
+        _ ->
+            Nothing
 
 
 {-| Get's the ID of the content that we are viewing.

--- a/frontend/src/Models/Story.elm
+++ b/frontend/src/Models/Story.elm
@@ -1,7 +1,7 @@
 module Models.Story exposing (..)
 
 import Date
-import DefaultServices.Util exposing (maybeMapWithDefault, getAt)
+import DefaultServices.Util exposing (getAt, maybeMapWithDefault)
 import Elements.Simple.Editor exposing (Language)
 import Models.Route as Route
 import Models.Tidbit as Tidbit
@@ -47,6 +47,7 @@ type alias ExpandedStory =
 {-| A new story being created, does not yet contain any db-added fields.
 
 This data structure can also represent the information for editing a story.
+
 -}
 type alias NewStory =
     { name : String
@@ -68,6 +69,7 @@ defaultNewStory =
 {-| A completely blank story.
 
 Meaningless stub-dates are used for the dates.
+
 -}
 blankStory : Story
 blankStory =

--- a/frontend/src/Models/TutorialBookmark.elm
+++ b/frontend/src/Models/TutorialBookmark.elm
@@ -1,5 +1,7 @@
 module Models.TutorialBookmark exposing (..)
 
+{-| -}
+
 
 {-| For tracking where we currently are in a tidbit.
 -}

--- a/frontend/src/Models/User.elm
+++ b/frontend/src/Models/User.elm
@@ -9,7 +9,7 @@ type alias User =
     { id : String
     , name : String
     , email : String
-    , password : Maybe (String)
+    , password : Maybe String
     , bio : String
     }
 
@@ -42,6 +42,7 @@ type alias UserUpdateRecord =
 {-| Gets the theme for a user.
 
 TODO Implement function
+
 -}
 getTheme : Maybe User -> String
 getTheme maybeUser =

--- a/frontend/src/Models/ViewerRelevantHC.elm
+++ b/frontend/src/Models/ViewerRelevantHC.elm
@@ -33,7 +33,7 @@ onFirstFrame =
 -}
 onLastFrame : ViewerRelevantHC a -> Bool
 onLastFrame vr =
-    vr.currentHC == Just ((Array.length vr.relevantHC) - 1)
+    vr.currentHC == Just (Array.length vr.relevantHC - 1)
 
 
 {-| Returns the current frame and the total number of frames, 1-based-indexing.
@@ -84,7 +84,7 @@ goToPreviousFrame vr =
             if onFirstFrame vr then
                 vr.currentHC
             else
-                Maybe.map ((flip (-)) 1) vr.currentHC
+                Maybe.map (flip (-) 1) vr.currentHC
     }
 
 
@@ -99,8 +99,8 @@ relevantHCTextAboveFrameSpecifyingPosition ( current, total ) =
           else
             text <|
                 "On frame "
-                    ++ (toString current)
+                    ++ toString current
                     ++ " of the "
-                    ++ (toString total)
+                    ++ toString total
                     ++ " frames that are related to your selection"
         ]

--- a/frontend/src/Models/Vote.elm
+++ b/frontend/src/Models/Vote.elm
@@ -1,11 +1,14 @@
 module Models.Vote exposing (..)
 
+{-| -}
+
 
 {-| For users placing opinions.
 
 Differs from `Rating` in the options, currently `Rating` can only be positive. `Vote` can be positive and negative.
 
 NOTE: Parralels to the `Vote` enum on the backend.
+
 -}
 type Vote
     = Upvote

--- a/frontend/src/Pages/Browse/JSON.elm
+++ b/frontend/src/Pages/Browse/JSON.elm
@@ -1,10 +1,10 @@
 module Pages.Browse.JSON exposing (..)
 
 import DefaultServices.Util exposing (justValueOrNull)
-import Json.Encode as Encode
-import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
 import JSON.Language
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
+import Json.Encode as Encode
 import Pages.Browse.Model exposing (..)
 
 

--- a/frontend/src/Pages/Browse/Model.elm
+++ b/frontend/src/Pages/Browse/Model.elm
@@ -1,7 +1,7 @@
 module Pages.Browse.Model exposing (..)
 
-import DefaultServices.Util as Util
 import DefaultServices.InfixFunctions exposing (..)
+import DefaultServices.Util as Util
 import Elements.Simple.Editor exposing (Language)
 import Models.Content exposing (Content)
 

--- a/frontend/src/Pages/Browse/Update.elm
+++ b/frontend/src/Pages/Browse/Update.elm
@@ -31,16 +31,15 @@ update ((Common common) as commonUtil) msg model shared =
                     common.handleAll
                         [ resetPageNumber
                         , performSearch
-                        , (\(Common common) ( model, shared ) ->
+                        , \(Common common) ( model, shared ) ->
                             common.justProduceCmd <|
                                 Cmd.batch
-                                    [ (Util.domFocus (always NoOp) "search-bar")
+                                    [ Util.domFocus (always NoOp) "search-bar"
                                     , if model.showAdvancedSearchOptions then
                                         Ports.expandSearchAdvancedOptions True
                                       else
                                         Cmd.none
                                     ]
-                          )
                         ]
 
                 _ ->
@@ -49,7 +48,7 @@ update ((Common common) as commonUtil) msg model shared =
         OnGetContentSuccess searchSettings content ->
             let
                 isMostRecentRequest =
-                    model.mostRecentSearchSettings == (Just searchSettings)
+                    model.mostRecentSearchSettings == Just searchSettings
 
                 getUpdatedModelForInitialRequest =
                     { model
@@ -86,8 +85,8 @@ update ((Common common) as commonUtil) msg model shared =
                     else
                         model
             in
-                common.justSetModel updatedModel
-                    |> common.andFinishRequest (RT.SearchForContent searchSettings)
+            common.justSetModel updatedModel
+                |> common.andFinishRequest (RT.SearchForContent searchSettings)
 
         OnGetContentFailure searchSettings apiError ->
             common.justSetModalError apiError
@@ -99,12 +98,11 @@ update ((Common common) as commonUtil) msg model shared =
         OnUpdateSearch newSearchQuery ->
             common.handleAll
                 [ -- Always update the model.
-                  (\(Common common) ( model, shared ) ->
+                  \(Common common) ( model, shared ) ->
                     common.justSetModel { model | searchQuery = newSearchQuery }
-                  )
 
                 -- Only perform a search automatically if we're back to an empty search query.
-                , (\(Common common) ( model, shared ) ->
+                , \(Common common) ( model, shared ) ->
                     if String.isEmpty newSearchQuery then
                         common.handleAll
                             [ resetPageNumber
@@ -112,7 +110,6 @@ update ((Common common) as commonUtil) msg model shared =
                             ]
                     else
                         common.doNothing
-                  )
                 ]
 
         Search ->
@@ -132,59 +129,58 @@ update ((Common common) as commonUtil) msg model shared =
                 updateFilterSnipbits (Common common) ( model, shared ) =
                     common.justSetModel { model | contentFilterSnipbits = not model.contentFilterSnipbits }
             in
-                if (not model.contentFilterBigbits) && (not model.contentFilterStories) then
-                    common.doNothing
-                else
-                    common.handleAll
-                        [ updateFilterSnipbits
-                        , resetPageNumber
-                        , performSearch
-                        ]
+            if not model.contentFilterBigbits && not model.contentFilterStories then
+                common.doNothing
+            else
+                common.handleAll
+                    [ updateFilterSnipbits
+                    , resetPageNumber
+                    , performSearch
+                    ]
 
         ToggleContentFilterBigbits ->
             let
                 updateFilterBigbits (Common common) ( model, shared ) =
                     common.justSetModel { model | contentFilterBigbits = not model.contentFilterBigbits }
             in
-                if (not model.contentFilterSnipbits) && (not model.contentFilterStories) then
-                    common.doNothing
-                else
-                    common.handleAll
-                        [ updateFilterBigbits
-                        , resetPageNumber
-                        , performSearch
-                        ]
+            if not model.contentFilterSnipbits && not model.contentFilterStories then
+                common.doNothing
+            else
+                common.handleAll
+                    [ updateFilterBigbits
+                    , resetPageNumber
+                    , performSearch
+                    ]
 
         ToggleContentFilterStories ->
             let
                 updateFilterStories (Common common) ( model, shared ) =
                     common.justSetModel { model | contentFilterStories = not model.contentFilterStories }
             in
-                if (not model.contentFilterSnipbits) && (not model.contentFilterBigbits) then
-                    common.doNothing
-                else
-                    common.handleAll
-                        [ updateFilterStories
-                        , resetPageNumber
-                        , performSearch
-                        ]
+            if not model.contentFilterSnipbits && not model.contentFilterBigbits then
+                common.doNothing
+            else
+                common.handleAll
+                    [ updateFilterStories
+                    , resetPageNumber
+                    , performSearch
+                    ]
 
         SetIncludeEmptyStories includeEmptyStories ->
             let
                 updateIncludeEmptyStories (Common common) ( model, shared ) =
                     common.justSetModel { model | contentFilterIncludeEmptyStories = includeEmptyStories }
             in
-                common.handleAll
-                    [ updateIncludeEmptyStories
-                    , resetPageNumber
-                    , performSearch
-                    ]
+            common.handleAll
+                [ updateIncludeEmptyStories
+                , resetPageNumber
+                , performSearch
+                ]
 
         SelectLanguage maybeLanguage ->
             common.handleAll
-                [ (\(Common common) ( model, shared ) ->
+                [ \(Common common) ( model, shared ) ->
                     common.justSetModel { model | contentFilterLanguage = maybeLanguage }
-                  )
                 , resetPageNumber
                 , performSearch
                 ]
@@ -196,50 +192,46 @@ update ((Common common) as commonUtil) msg model shared =
                         |> Tuple.second
                         |> Util.isNotNothing
             in
-                common.handleAll
-                    [ -- We always update the model.
-                      (\(Common common) ( model, shared ) ->
-                        common.justSetModel { model | contentFilterAuthor = ( newAuthorInput, Nothing ) }
-                      )
+            common.handleAll
+                [ -- We always update the model.
+                  \(Common common) ( model, shared ) ->
+                    common.justSetModel { model | contentFilterAuthor = ( newAuthorInput, Nothing ) }
 
-                    -- We only need to perform a search if their was an author before and we just cleared it.
-                    , (\(Common common) ( model, shared ) ->
-                        if wasAuthor then
-                            common.handleAll
-                                [ resetPageNumber
-                                , performSearch
-                                ]
-                        else
-                            common.doNothing
-                      )
+                -- We only need to perform a search if their was an author before and we just cleared it.
+                , \(Common common) ( model, shared ) ->
+                    if wasAuthor then
+                        common.handleAll
+                            [ resetPageNumber
+                            , performSearch
+                            ]
+                    else
+                        common.doNothing
 
-                    -- We need to check if the new input is a valid email, unless the new input is an empty string.
-                    , (\(Common common) ( model, shared ) ->
-                        if String.isEmpty newAuthorInput then
-                            common.doNothing
-                        else
-                            common.justProduceCmd <|
-                                common.api.get.userExists
-                                    newAuthorInput
-                                    OnGetUserExistsFailure
-                                    (OnGetUserExistsSuccess << ((,) newAuthorInput))
-                      )
-                    ]
+                -- We need to check if the new input is a valid email, unless the new input is an empty string.
+                , \(Common common) ( model, shared ) ->
+                    if String.isEmpty newAuthorInput then
+                        common.doNothing
+                    else
+                        common.justProduceCmd <|
+                            common.api.get.userExists
+                                newAuthorInput
+                                OnGetUserExistsFailure
+                                (OnGetUserExistsSuccess << (,) newAuthorInput)
+                ]
 
         OnGetUserExistsFailure apiError ->
             common.justSetModalError apiError
 
         OnGetUserExistsSuccess (( forEmail, maybeID ) as newContentFilterAuthor) ->
             -- The user may have typed more before the request returned, in which case we don't care about the request.
-            if forEmail == (Tuple.first model.contentFilterAuthor) then
+            if forEmail == Tuple.first model.contentFilterAuthor then
                 common.handleAll
                     [ -- We always update the model.
-                      (\(Common common) ( model, shared ) ->
+                      \(Common common) ( model, shared ) ->
                         common.justSetModel { model | contentFilterAuthor = newContentFilterAuthor }
-                      )
 
                     -- If a valid email has been past then we perform a search (with the user filter).
-                    , (\(Common common) ( model, shared ) ->
+                    , \(Common common) ( model, shared ) ->
                         if Util.isNotNothing maybeID then
                             common.handleAll
                                 [ resetPageNumber
@@ -247,7 +239,6 @@ update ((Common common) as commonUtil) msg model shared =
                                 ]
                         else
                             common.doNothing
-                      )
                     ]
             else
                 common.doNothing
@@ -262,6 +253,7 @@ already in progress.
 NOTE (2):
 Will also update `mostRecentSearchSettings` to keep track of what the most recent search request was, this allows us
 to know what results from the server are still meaningful.
+
 -}
 performSearch : CommonSubPageUtil Model Shared Msg -> ( Model, Shared ) -> ( Model, Shared, Cmd Msg )
 performSearch (Common common) ( model, shared ) =
@@ -305,19 +297,20 @@ performSearch (Common common) ( model, shared ) =
                 , shared
                 , getContent <|
                     commonQueryParams
-                        ++ case searchSettings.searchQuery of
-                            Nothing ->
-                                [ ( "sortByLastModified", Just "true" ) ]
+                        ++ (case searchSettings.searchQuery of
+                                Nothing ->
+                                    [ ( "sortByLastModified", Just "true" ) ]
 
-                            Just searchQuery ->
-                                [ ( "searchQuery", Just searchQuery )
-                                , ( "sortByTextScore", Just "true" )
-                                ]
+                                Just searchQuery ->
+                                    [ ( "searchQuery", Just searchQuery )
+                                    , ( "sortByTextScore", Just "true" )
+                                    ]
+                           )
                 )
     in
-        -- Regardless of whether we actually performed the singleton request, we need to mark that it is the most
-        -- recent request.
-        ( { newModel | mostRecentSearchSettings = Just searchSettings }, newShared, newCmd )
+    -- Regardless of whether we actually performed the singleton request, we need to mark that it is the most
+    -- recent request.
+    ( { newModel | mostRecentSearchSettings = Just searchSettings }, newShared, newCmd )
 
 
 {-| Resets the page number back to 1.
@@ -351,4 +344,4 @@ isNoMoreContent pageSize content =
                         Content.Story _ ->
                             go ( snipbits, bigbits, stories + 1 ) xs
     in
-        go ( 0, 0, 0 ) content
+    go ( 0, 0, 0 ) content

--- a/frontend/src/Pages/Browse/View.elm
+++ b/frontend/src/Pages/Browse/View.elm
@@ -3,8 +3,8 @@ module Pages.Browse.View exposing (..)
 import DefaultServices.Util as Util
 import Elements.Simple.ContentBox as ContentBox
 import Elements.Simple.Editor as Editor
-import Html exposing (Html, div, text, button, input, span, i, select, option)
-import Html.Attributes exposing (class, hidden, classList, placeholder, value, id, disabled, selected)
+import Html exposing (Html, button, div, i, input, option, select, span, text)
+import Html.Attributes exposing (class, classList, disabled, hidden, id, placeholder, selected, value)
 import Html.Events exposing (onClick, onInput)
 import Keyboard.Extra as KK
 import Pages.Browse.Messages exposing (..)
@@ -95,18 +95,16 @@ view model shared =
                     [ span [ class "language-filter-title" ] [ text "Select Language" ]
                     , select
                         [ Util.onChange (Editor.languageFromHumanReadableName >> SelectLanguage) ]
-                        ((option
+                        (option
                             [ selected <| Util.isNothing model.contentFilterLanguage ]
                             [ text "All" ]
-                         )
-                            :: (List.map
-                                    (\( language, humanReadableName ) ->
-                                        option
-                                            [ selected <| Just language == model.contentFilterLanguage ]
-                                            [ text humanReadableName ]
-                                    )
-                                    Editor.humanReadableListOfLanguages
-                               )
+                            :: List.map
+                                (\( language, humanReadableName ) ->
+                                    option
+                                        [ selected <| Just language == model.contentFilterLanguage ]
+                                        [ text humanReadableName ]
+                                )
+                                Editor.humanReadableListOfLanguages
                         )
                     ]
                 , div
@@ -136,7 +134,7 @@ view model shared =
                 ]
             ]
         , div [ class "sub-bar-ghost hidden" ] []
-        , (case model.content of
+        , case model.content of
             Nothing ->
                 Util.hiddenDiv
 
@@ -153,7 +151,7 @@ view model shared =
                         [ class "all-content" ]
                         (content
                             |> List.map (ContentBox.view { goToMsg = GoTo, darkenBox = False, forStory = Nothing })
-                            |> (flip (++)) Util.emptyFlexBoxesForAlignment
+                            |> flip (++) Util.emptyFlexBoxesForAlignment
                         )
                     , button
                         [ classList
@@ -180,7 +178,6 @@ view model shared =
                                     text "no more results"
                         ]
                     ]
-          )
         ]
 
 

--- a/frontend/src/Pages/Create/JSON.elm
+++ b/frontend/src/Pages/Create/JSON.elm
@@ -3,7 +3,7 @@ module Pages.Create.JSON exposing (..)
 import DefaultServices.Util as Util
 import JSON.TidbitType
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.Create.Model exposing (..)
 

--- a/frontend/src/Pages/Create/View.elm
+++ b/frontend/src/Pages/Create/View.elm
@@ -2,7 +2,7 @@ module Pages.Create.View exposing (..)
 
 import DefaultServices.Util as Util
 import Elements.Simple.Editor exposing (prettyPrintLanguages)
-import Html exposing (Html, div, text, button, i)
+import Html exposing (Html, button, div, i, text)
 import Html.Attributes exposing (class, classList)
 import Html.Events exposing (onClick)
 import Models.Route as Route
@@ -39,7 +39,7 @@ view model shared =
         makeTidbitTypeBox title subTitle description onClickMsg tidbitType =
             div
                 [ class "create-select-tidbit-type" ]
-                (if model.showInfoFor == (Just tidbitType) then
+                (if model.showInfoFor == Just tidbitType then
                     [ div
                         [ class "description-text" ]
                         [ text description ]
@@ -91,66 +91,65 @@ view model shared =
                                     [ text "add" ]
                                 ]
                              ]
-                                ++ (List.map
-                                        (\story ->
-                                            div
-                                                [ class "story-box"
-                                                , onClick <| GoTo <| Route.DevelopStoryPage story.id
+                                ++ List.map
+                                    (\story ->
+                                        div
+                                            [ class "story-box"
+                                            , onClick <| GoTo <| Route.DevelopStoryPage story.id
+                                            ]
+                                            [ div
+                                                [ class "story-box-name" ]
+                                                [ text story.name ]
+                                            , div
+                                                [ class "story-box-languages" ]
+                                                [ text <| prettyPrintLanguages <| story.languages
                                                 ]
-                                                [ div
-                                                    [ class "story-box-name" ]
-                                                    [ text story.name ]
-                                                , div
-                                                    [ class "story-box-languages" ]
-                                                    [ text <| prettyPrintLanguages <| story.languages
-                                                    ]
-                                                , div
-                                                    [ class "story-box-tidbit-count" ]
-                                                    [ text <| Util.xThings "tidbit" "s" <| List.length story.tidbitPointers ]
-                                                , div
-                                                    [ class "story-box-opinions" ]
-                                                    [ i [ class "material-icons" ] [ text "favorite" ]
-                                                    , div [ class "like-count" ] [ text <| toString <| story.likes ]
-                                                    ]
+                                            , div
+                                                [ class "story-box-tidbit-count" ]
+                                                [ text <| Util.xThings "tidbit" "s" <| List.length story.tidbitPointers ]
+                                            , div
+                                                [ class "story-box-opinions" ]
+                                                [ i [ class "material-icons" ] [ text "favorite" ]
+                                                , div [ class "like-count" ] [ text <| toString <| story.likes ]
                                                 ]
-                                        )
-                                        (List.reverse <| Util.sortByDate .lastModified userStories)
-                                   )
+                                            ]
+                                    )
+                                    (List.reverse <| Util.sortByDate .lastModified userStories)
                                 ++ Util.emptyFlexBoxesForAlignment
                             )
                         ]
     in
-        div
-            [ class "create-page" ]
-            [ div
-                [ class "title-banner" ]
-                [ text "CREATE TIDBIT" ]
+    div
+        [ class "create-page" ]
+        [ div
+            [ class "title-banner" ]
+            [ text "CREATE TIDBIT" ]
+        , div
+            [ class "make-tidbits" ]
+            [ makeTidbitTypeBox
+                "SnipBit"
+                "Explain a chunk of code"
+                snipBitDescription
+                (GoTo Route.CreateSnipbitNamePage)
+                SnipBit
+            , makeTidbitTypeBox
+                "BigBit"
+                "Explain a full project"
+                bigBitInfo
+                (GoTo Route.CreateBigbitNamePage)
+                BigBit
             , div
-                [ class "make-tidbits" ]
-                [ makeTidbitTypeBox
-                    "SnipBit"
-                    "Explain a chunk of code"
-                    snipBitDescription
-                    (GoTo Route.CreateSnipbitNamePage)
-                    SnipBit
-                , makeTidbitTypeBox
-                    "BigBit"
-                    "Explain a full project"
-                    bigBitInfo
-                    (GoTo Route.CreateBigbitNamePage)
-                    BigBit
+                [ class "create-select-tidbit-type-coming-soon" ]
+                [ div
+                    [ class "coming-soon-text" ]
+                    [ text "More Coming Soon" ]
                 , div
-                    [ class "create-select-tidbit-type-coming-soon" ]
-                    [ div
-                        [ class "coming-soon-text" ]
-                        [ text "More Coming Soon" ]
-                    , div
-                        [ class "coming-soon-sub-text" ]
-                        [ text "We are working on it" ]
-                    ]
+                    [ class "coming-soon-sub-text" ]
+                    [ text "We are working on it" ]
                 ]
-            , div
-                [ class "title-banner story-banner" ]
-                [ text "DEVELOP STORY" ]
-            , yourStoriesHtml
             ]
+        , div
+            [ class "title-banner story-banner" ]
+            [ text "DEVELOP STORY" ]
+        , yourStoriesHtml
+        ]

--- a/frontend/src/Pages/CreateBigbit/JSON.elm
+++ b/frontend/src/Pages/CreateBigbit/JSON.elm
@@ -7,9 +7,9 @@ import JSON.FileStructure
 import JSON.Language
 import JSON.Range
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
-import Models.Bigbit exposing (FolderMetadata, FileMetadata)
+import Models.Bigbit exposing (FileMetadata, FolderMetadata)
 import Models.Range as Range
 import Pages.CreateBigbit.Model exposing (..)
 
@@ -35,19 +35,19 @@ encoder model =
                 (\folderMetadata -> Encode.object [ ( "isExpanded", Encode.bool folderMetadata.isExpanded ) ])
                 (\fileMetadata -> Encode.object [ ( "language", JSON.Language.encoder fileMetadata.language ) ])
     in
-        Encode.object
-            [ ( "name", Encode.string model.name )
-            , ( "description", Encode.string model.description )
-            , ( "tags", Encode.list <| List.map Encode.string model.tags )
-            , ( "tagInput", Encode.string model.tagInput )
-            , ( "introduction", Encode.string model.introduction )
-            , ( "conclusion", Encode.string model.conclusion )
-            , ( "fs", fsEncoder model.fs )
-            , ( "highlightedComments"
-              , Encode.array <| Array.map createHighlightedCommentEncoder model.highlightedComments
-              )
-            , ( "previewMarkdown", Encode.bool model.previewMarkdown )
-            ]
+    Encode.object
+        [ ( "name", Encode.string model.name )
+        , ( "description", Encode.string model.description )
+        , ( "tags", Encode.list <| List.map Encode.string model.tags )
+        , ( "tagInput", Encode.string model.tagInput )
+        , ( "introduction", Encode.string model.introduction )
+        , ( "conclusion", Encode.string model.conclusion )
+        , ( "fs", fsEncoder model.fs )
+        , ( "highlightedComments"
+          , Encode.array <| Array.map createHighlightedCommentEncoder model.highlightedComments
+          )
+        , ( "previewMarkdown", Encode.bool model.previewMarkdown )
+        ]
 
 
 {-| `CreateBigbit` decoder.
@@ -71,16 +71,16 @@ decoder =
                     |> required "language" JSON.Language.decoder
                 )
     in
-        decode Model
-            |> required "name" Decode.string
-            |> required "description" Decode.string
-            |> required "tags" (Decode.list Decode.string)
-            |> required "tagInput" Decode.string
-            |> required "introduction" Decode.string
-            |> required "conclusion" Decode.string
-            |> required "fs" fsDecoder
-            |> required "highlightedComments" (Decode.array createHighlightedCommentDecoder)
-            |> required "previewMarkdown" Decode.bool
+    decode Model
+        |> required "name" Decode.string
+        |> required "description" Decode.string
+        |> required "tags" (Decode.list Decode.string)
+        |> required "tagInput" Decode.string
+        |> required "introduction" Decode.string
+        |> required "conclusion" Decode.string
+        |> required "fs" fsDecoder
+        |> required "highlightedComments" (Decode.array createHighlightedCommentDecoder)
+        |> required "previewMarkdown" Decode.bool
 
 
 {-| `FSActionButtonState` encoder.
@@ -112,8 +112,8 @@ fsActionButtonStateDecoder =
                 _ ->
                     Decode.fail <| "Not a valid encoded action state: " ++ encodedActionState
     in
-        Decode.string
-            |> Decode.andThen fromStringDecoder
+    Decode.string
+        |> Decode.andThen fromStringDecoder
 
 
 {-| `BigbitForPublication` encoder.
@@ -128,15 +128,15 @@ publicationEncoder bigbit =
                 (\fileMetadata -> Encode.object [ ( "language", JSON.Language.encoder fileMetadata.language ) ])
                 fs
     in
-        Encode.object
-            [ ( "name", Encode.string bigbit.name )
-            , ( "description", Encode.string bigbit.description )
-            , ( "tags", Encode.list <| List.map Encode.string bigbit.tags )
-            , ( "introduction", Encode.string bigbit.introduction )
-            , ( "conclusion", Encode.string bigbit.conclusion )
-            , ( "fs", fsEncoder bigbit.fs )
-            , ( "highlightedComments", Encode.list <| List.map highlightedCommentEncoder bigbit.highlightedComments )
-            ]
+    Encode.object
+        [ ( "name", Encode.string bigbit.name )
+        , ( "description", Encode.string bigbit.description )
+        , ( "tags", Encode.list <| List.map Encode.string bigbit.tags )
+        , ( "introduction", Encode.string bigbit.introduction )
+        , ( "conclusion", Encode.string bigbit.conclusion )
+        , ( "fs", fsEncoder bigbit.fs )
+        , ( "highlightedComments", Encode.list <| List.map highlightedCommentEncoder bigbit.highlightedComments )
+        ]
 
 
 {-| `HighlightedCommentForCreate` encoder.
@@ -170,6 +170,6 @@ createHighlightedCommentDecoder =
                     |> required "file" Decode.string
                 )
     in
-        decode HighlightedCommentForCreate
-            |> required "comment" Decode.string
-            |> required "fileAndRange" decodeFileAndRange
+    decode HighlightedCommentForCreate
+        |> required "comment" Decode.string
+        |> required "fileAndRange" decodeFileAndRange

--- a/frontend/src/Pages/CreateBigbit/Update.elm
+++ b/frontend/src/Pages/CreateBigbit/Update.elm
@@ -26,620 +26,618 @@ update (Common common) msg model shared =
         currentBigbitHighlightedComments =
             model.highlightedComments
     in
-        case msg of
-            NoOp ->
-                common.doNothing
+    case msg of
+        NoOp ->
+            common.doNothing
 
-            GoTo route ->
-                common.justProduceCmd <| Route.navigateTo route
+        GoTo route ->
+            common.justProduceCmd <| Route.navigateTo route
 
-            OnRouteHit route ->
-                let
-                    createCreateBigbitEditorForCurrentFile maybeRange maybeFilePath backupRoute =
+        OnRouteHit route ->
+            let
+                createCreateBigbitEditorForCurrentFile maybeRange maybeFilePath backupRoute =
+                    Cmd.batch
+                        [ case maybeFilePath of
+                            Nothing ->
+                                Ports.createCodeEditor
+                                    { id = "create-bigbit-code-editor"
+                                    , fileID = ""
+                                    , lang = ""
+                                    , theme = User.getTheme shared.user
+                                    , value = ""
+                                    , range = Nothing
+                                    , useMarker = True -- Doesn't matter, no range.
+                                    , readOnly = True
+                                    , selectAllowed = True
+                                    }
+
+                            Just filePath ->
+                                case FS.getFile model.fs filePath of
+                                    Nothing ->
+                                        Route.navigateTo backupRoute
+
+                                    Just (FS.File content { language }) ->
+                                        Ports.createCodeEditor
+                                            { id = "create-bigbit-code-editor"
+                                            , fileID = FS.uniqueFilePath filePath
+                                            , lang = Editor.aceLanguageLocation language
+                                            , theme = User.getTheme shared.user
+                                            , value = content
+                                            , range = maybeRange
+                                            , useMarker = False
+                                            , readOnly = False
+                                            , selectAllowed = True
+                                            }
+                        , Ports.smoothScrollToBottom
+                        ]
+
+                focusOn theID =
+                    common.justProduceCmd <| Util.domFocus (\_ -> NoOp) theID
+            in
+            case route of
+                Route.CreateBigbitNamePage ->
+                    focusOn "name-input"
+
+                Route.CreateBigbitDescriptionPage ->
+                    focusOn "description-input"
+
+                Route.CreateBigbitTagsPage ->
+                    focusOn "tags-input"
+
+                Route.CreateBigbitCodeIntroductionPage maybeFilePath ->
+                    common.justProduceCmd <|
                         Cmd.batch
-                            [ case maybeFilePath of
-                                Nothing ->
-                                    Ports.createCodeEditor
-                                        { id = "create-bigbit-code-editor"
-                                        , fileID = ""
-                                        , lang = ""
-                                        , theme = User.getTheme shared.user
-                                        , value = ""
-                                        , range = Nothing
-                                        , useMarker = True -- Doesn't matter, no range.
-                                        , readOnly = True
-                                        , selectAllowed = True
-                                        }
-
-                                Just filePath ->
-                                    case FS.getFile model.fs filePath of
-                                        Nothing ->
-                                            Route.navigateTo backupRoute
-
-                                        Just (FS.File content { language }) ->
-                                            Ports.createCodeEditor
-                                                { id = "create-bigbit-code-editor"
-                                                , fileID = FS.uniqueFilePath filePath
-                                                , lang = Editor.aceLanguageLocation language
-                                                , theme = User.getTheme shared.user
-                                                , value = content
-                                                , range = maybeRange
-                                                , useMarker = False
-                                                , readOnly = False
-                                                , selectAllowed = True
-                                                }
-                            , Ports.smoothScrollToBottom
+                            [ createCreateBigbitEditorForCurrentFile
+                                Nothing
+                                maybeFilePath
+                                (Route.CreateBigbitCodeIntroductionPage Nothing)
+                            , Util.domFocus (\_ -> NoOp) "introduction-input"
                             ]
 
-                    focusOn theID =
-                        common.justProduceCmd <| Util.domFocus (\_ -> NoOp) theID
-                in
-                    case route of
-                        Route.CreateBigbitNamePage ->
-                            focusOn "name-input"
-
-                        Route.CreateBigbitDescriptionPage ->
-                            focusOn "description-input"
-
-                        Route.CreateBigbitTagsPage ->
-                            focusOn "tags-input"
-
-                        Route.CreateBigbitCodeIntroductionPage maybeFilePath ->
-                            common.justProduceCmd <|
-                                Cmd.batch
-                                    [ createCreateBigbitEditorForCurrentFile
-                                        Nothing
-                                        maybeFilePath
-                                        (Route.CreateBigbitCodeIntroductionPage Nothing)
-                                    , Util.domFocus (\_ -> NoOp) "introduction-input"
-                                    ]
-
-                        Route.CreateBigbitCodeFramePage frameNumber maybeFilePath ->
-                            if frameNumber < 1 then
-                                common.justProduceCmd <| Route.modifyTo <| Route.CreateBigbitCodeIntroductionPage Nothing
-                            else if frameNumber > (Array.length currentBigbitHighlightedComments) then
-                                common.justProduceCmd <| Route.modifyTo <| Route.CreateBigbitCodeConclusionPage Nothing
-                            else
-                                let
-                                    -- Update the HC if the route has a file path.
-                                    hcUpdaterIfOnFilePath currentHighlightedComment filePath =
-                                        case currentHighlightedComment.fileAndRange of
-                                            -- Brand new frame, attempting to use range of previous frame.
-                                            Nothing ->
-                                                { currentHighlightedComment
-                                                    | fileAndRange =
-                                                        Just
-                                                            { range =
-                                                                case previousFrameRange model shared.route of
-                                                                    Nothing ->
-                                                                        Nothing
-
-                                                                    Just ( prevFilePath, range ) ->
-                                                                        if FS.isSameFilePath filePath prevFilePath then
-                                                                            Just <| Range.collapseRange range
-                                                                        else
-                                                                            Nothing
-                                                            , file = filePath
-                                                            }
-                                                }
-
-                                            -- Refreshed/changed file path for current frame.
-                                            Just fileAndRange ->
-                                                if FS.isSameFilePath fileAndRange.file filePath then
-                                                    currentHighlightedComment
-                                                else
-                                                    { currentHighlightedComment
-                                                        | fileAndRange = Just { range = Nothing, file = filePath }
-                                                    }
-
-                                    -- Update the HC depending on the `maybeFilePath`.
-                                    hcUpdater currentHighlightedComment =
-                                        case maybeFilePath of
-                                            Nothing ->
-                                                { currentHighlightedComment | fileAndRange = Nothing }
-
-                                            Just filePath ->
-                                                hcUpdaterIfOnFilePath currentHighlightedComment filePath
-
-                                    newModel =
-                                        updateHCAtIndex model (frameNumber - 1) hcUpdater
-
-                                    maybeRangeToHighlight =
-                                        Array.get (frameNumber - 1) newModel.highlightedComments
-                                            |> Maybe.andThen .fileAndRange
-                                            |> Maybe.andThen .range
-                                in
-                                    ( newModel
-                                    , shared
-                                    , Cmd.batch
-                                        [ createCreateBigbitEditorForCurrentFile
-                                            maybeRangeToHighlight
-                                            maybeFilePath
-                                            (Route.CreateBigbitCodeFramePage frameNumber Nothing)
-                                        , Util.domFocus (\_ -> NoOp) "frame-input"
-                                        ]
-                                    )
-
-                        Route.CreateBigbitCodeConclusionPage maybeFilePath ->
-                            common.justProduceCmd <|
-                                Cmd.batch
-                                    [ createCreateBigbitEditorForCurrentFile
-                                        Nothing
-                                        maybeFilePath
-                                        (Route.CreateBigbitCodeConclusionPage Nothing)
-                                    , Util.domFocus (\_ -> NoOp) "conclusion-input"
-                                    ]
-
-                        _ ->
-                            common.doNothing
-
-            -- Update the code and also check if any ranges are out of range and update those ranges.
-            OnUpdateCode { newCode, action, deltaRange } ->
-                case createBigbitPageCurrentActiveFile shared.route of
-                    Nothing ->
-                        common.doNothing
-
-                    Just filePath ->
+                Route.CreateBigbitCodeFramePage frameNumber maybeFilePath ->
+                    if frameNumber < 1 then
+                        common.justProduceCmd <| Route.modifyTo <| Route.CreateBigbitCodeIntroductionPage Nothing
+                    else if frameNumber > Array.length currentBigbitHighlightedComments then
+                        common.justProduceCmd <| Route.modifyTo <| Route.CreateBigbitCodeConclusionPage Nothing
+                    else
                         let
-                            currentCode =
-                                FS.getFile model.fs filePath
-                                    |> maybeMapWithDefault (\(FS.File content _) -> content) ""
-
-                            newFS =
-                                model.fs
-                                    |> FS.updateFile
-                                        filePath
-                                        (\(FS.File content fileMetadata) -> FS.File newCode fileMetadata)
-
-                            newHC =
-                                Array.map
-                                    (\comment ->
-                                        case comment.fileAndRange of
-                                            Nothing ->
-                                                comment
-
-                                            Just { file, range } ->
-                                                if FS.isSameFilePath file filePath then
-                                                    case range of
-                                                        Nothing ->
-                                                            comment
-
-                                                        Just aRange ->
-                                                            { comment
-                                                                | fileAndRange =
-                                                                    Just
-                                                                        { file = file
-                                                                        , range =
-                                                                            Just <|
-                                                                                Range.getNewRangeAfterDelta
-                                                                                    currentCode
-                                                                                    newCode
-                                                                                    action
-                                                                                    deltaRange
-                                                                                    aRange
-                                                                        }
-                                                            }
-                                                else
-                                                    comment
-                                    )
-                                    currentBigbitHighlightedComments
-                        in
-                            common.justSetModel
-                                { model
-                                    | fs = newFS
-                                    , highlightedComments = newHC
-                                }
-
-            OnRangeSelected newRange ->
-                case shared.route of
-                    Route.CreateBigbitCodeFramePage frameNumber currentPath ->
-                        case Array.get (frameNumber - 1) currentBigbitHighlightedComments of
-                            Nothing ->
-                                common.doNothing
-
-                            Just highlightedComment ->
-                                case highlightedComment.fileAndRange of
+                            -- Update the HC if the route has a file path.
+                            hcUpdaterIfOnFilePath currentHighlightedComment filePath =
+                                case currentHighlightedComment.fileAndRange of
+                                    -- Brand new frame, attempting to use range of previous frame.
                                     Nothing ->
-                                        common.doNothing
+                                        { currentHighlightedComment
+                                            | fileAndRange =
+                                                Just
+                                                    { range =
+                                                        case previousFrameRange model shared.route of
+                                                            Nothing ->
+                                                                Nothing
 
+                                                            Just ( prevFilePath, range ) ->
+                                                                if FS.isSameFilePath filePath prevFilePath then
+                                                                    Just <| Range.collapseRange range
+                                                                else
+                                                                    Nothing
+                                                    , file = filePath
+                                                    }
+                                        }
+
+                                    -- Refreshed/changed file path for current frame.
                                     Just fileAndRange ->
-                                        common.justSetModel
-                                            { model
-                                                | highlightedComments =
-                                                    Array.set
-                                                        (frameNumber - 1)
-                                                        { highlightedComment
-                                                            | fileAndRange =
-                                                                Just { fileAndRange | range = Just newRange }
-                                                        }
-                                                        currentBigbitHighlightedComments
+                                        if FS.isSameFilePath fileAndRange.file filePath then
+                                            currentHighlightedComment
+                                        else
+                                            { currentHighlightedComment
+                                                | fileAndRange = Just { range = Nothing, file = filePath }
                                             }
 
-                    _ ->
-                        common.doNothing
+                            -- Update the HC depending on the `maybeFilePath`.
+                            hcUpdater currentHighlightedComment =
+                                case maybeFilePath of
+                                    Nothing ->
+                                        { currentHighlightedComment | fileAndRange = Nothing }
 
-            GoToCodeTab ->
-                ( { model | previewMarkdown = False }
-                , shared
-                , Route.navigateTo <| Route.CreateBigbitCodeIntroductionPage Nothing
-                )
+                                    Just filePath ->
+                                        hcUpdaterIfOnFilePath currentHighlightedComment filePath
 
-            Reset ->
-                ( init
-                , shared
-                , Route.navigateTo Route.CreateBigbitNamePage
-                )
+                            newModel =
+                                updateHCAtIndex model (frameNumber - 1) hcUpdater
 
-            AddFrame ->
-                let
-                    currentPath =
-                        createBigbitPageCurrentActiveFile shared.route
-
-                    newModel =
-                        { model
-                            | highlightedComments =
-                                Array.push emptyHighlightCommentForCreate currentBigbitHighlightedComments
-                        }
-
-                    newCmd =
-                        Route.navigateTo <|
-                            Route.CreateBigbitCodeFramePage (Array.length newModel.highlightedComments) currentPath
-                in
-                    ( newModel, shared, newCmd )
-
-            RemoveFrame ->
-                if Array.length currentBigbitHighlightedComments == 1 then
-                    common.doNothing
-                else
-                    let
-                        newHighlightedComments =
-                            Array.slice
-                                0
-                                (Array.length currentBigbitHighlightedComments - 1)
-                                currentBigbitHighlightedComments
-
-                        newModel =
-                            { model | highlightedComments = newHighlightedComments }
-
-                        -- Have to make sure if they are on the last frame it pushes them down one frame.
-                        newRoute =
-                            case shared.route of
-                                Route.CreateBigbitCodeFramePage frameNumber filePath ->
-                                    Just <|
-                                        Route.CreateBigbitCodeFramePage
-                                            (if frameNumber == (Array.length currentBigbitHighlightedComments) then
-                                                (frameNumber - 1)
-                                             else
-                                                frameNumber
-                                            )
-                                            filePath
-
-                                _ ->
-                                    Nothing
-
-                        newCmd =
-                            maybeMapWithDefault Route.modifyTo Cmd.none newRoute
-                    in
-                        ( newModel, shared, newCmd )
-
-            ToggleFS ->
-                common.justSetModel { model | fs = Bigbit.toggleFS model.fs }
-
-            ToggleFolder folderPath ->
-                common.justSetModel { model | fs = Bigbit.toggleFSFolder folderPath model.fs }
-
-            SelectFile absolutePath ->
-                common.justProduceCmd <| Route.navigateToSameUrlWithFilePath (Just absolutePath) shared.route
-
-            TogglePreviewMarkdown ->
-                common.justUpdateModel togglePreviewMarkdown
-
-            AddFile absolutePath language ->
-                common.justSetModel <|
-                    { model
-                        | fs =
-                            model.fs
-                                |> (FS.addFile
-                                        { overwriteExisting = False
-                                        , forceCreateDirectories = Just <| always defaultEmptyFolder
-                                        }
-                                        absolutePath
-                                        (FS.emptyFile { language = language })
-                                   )
-                                |> clearActionButtonInput
-                    }
-
-            JumpToLineFromPreviousFrame filePath ->
-                case shared.route of
-                    Route.CreateBigbitCodeFramePage frameNumber _ ->
-                        ( updateHCAtIndex
-                            model
-                            (frameNumber - 1)
-                            (\hcAtIndex -> { hcAtIndex | fileAndRange = Nothing })
+                            maybeRangeToHighlight =
+                                Array.get (frameNumber - 1) newModel.highlightedComments
+                                    |> Maybe.andThen .fileAndRange
+                                    |> Maybe.andThen .range
+                        in
+                        ( newModel
                         , shared
-                        , Route.modifyTo <| Route.CreateBigbitCodeFramePage frameNumber (Just filePath)
+                        , Cmd.batch
+                            [ createCreateBigbitEditorForCurrentFile
+                                maybeRangeToHighlight
+                                maybeFilePath
+                                (Route.CreateBigbitCodeFramePage frameNumber Nothing)
+                            , Util.domFocus (\_ -> NoOp) "frame-input"
+                            ]
                         )
 
-                    _ ->
-                        common.doNothing
+                Route.CreateBigbitCodeConclusionPage maybeFilePath ->
+                    common.justProduceCmd <|
+                        Cmd.batch
+                            [ createCreateBigbitEditorForCurrentFile
+                                Nothing
+                                maybeFilePath
+                                (Route.CreateBigbitCodeConclusionPage Nothing)
+                            , Util.domFocus (\_ -> NoOp) "conclusion-input"
+                            ]
 
-            OnUpdateName newName ->
-                common.justSetModel { model | name = newName }
+                _ ->
+                    common.doNothing
 
-            OnUpdateDescription newDescription ->
-                common.justSetModel { model | description = newDescription }
+        -- Update the code and also check if any ranges are out of range and update those ranges.
+        OnUpdateCode { newCode, action, deltaRange } ->
+            case createBigbitPageCurrentActiveFile shared.route of
+                Nothing ->
+                    common.doNothing
 
-            OnUpdateTagInput newTagInput ->
-                if String.endsWith " " newTagInput then
+                Just filePath ->
                     let
-                        newTag =
-                            String.dropRight 1 newTagInput
+                        currentCode =
+                            FS.getFile model.fs filePath
+                                |> maybeMapWithDefault (\(FS.File content _) -> content) ""
 
-                        newTags =
-                            Util.addUniqueNonEmptyString newTag model.tags
+                        newFS =
+                            model.fs
+                                |> FS.updateFile
+                                    filePath
+                                    (\(FS.File content fileMetadata) -> FS.File newCode fileMetadata)
+
+                        newHC =
+                            Array.map
+                                (\comment ->
+                                    case comment.fileAndRange of
+                                        Nothing ->
+                                            comment
+
+                                        Just { file, range } ->
+                                            if FS.isSameFilePath file filePath then
+                                                case range of
+                                                    Nothing ->
+                                                        comment
+
+                                                    Just aRange ->
+                                                        { comment
+                                                            | fileAndRange =
+                                                                Just
+                                                                    { file = file
+                                                                    , range =
+                                                                        Just <|
+                                                                            Range.getNewRangeAfterDelta
+                                                                                currentCode
+                                                                                newCode
+                                                                                action
+                                                                                deltaRange
+                                                                                aRange
+                                                                    }
+                                                        }
+                                            else
+                                                comment
+                                )
+                                currentBigbitHighlightedComments
                     in
-                        common.justSetModel
-                            { model
-                                | tags = newTags
-                                , tagInput = ""
-                            }
-                else
-                    common.justSetModel { model | tagInput = newTagInput }
+                    common.justSetModel
+                        { model
+                            | fs = newFS
+                            , highlightedComments = newHC
+                        }
 
-            AddTag tagName ->
-                common.justSetModel
+        OnRangeSelected newRange ->
+            case shared.route of
+                Route.CreateBigbitCodeFramePage frameNumber currentPath ->
+                    case Array.get (frameNumber - 1) currentBigbitHighlightedComments of
+                        Nothing ->
+                            common.doNothing
+
+                        Just highlightedComment ->
+                            case highlightedComment.fileAndRange of
+                                Nothing ->
+                                    common.doNothing
+
+                                Just fileAndRange ->
+                                    common.justSetModel
+                                        { model
+                                            | highlightedComments =
+                                                Array.set
+                                                    (frameNumber - 1)
+                                                    { highlightedComment
+                                                        | fileAndRange =
+                                                            Just { fileAndRange | range = Just newRange }
+                                                    }
+                                                    currentBigbitHighlightedComments
+                                        }
+
+                _ ->
+                    common.doNothing
+
+        GoToCodeTab ->
+            ( { model | previewMarkdown = False }
+            , shared
+            , Route.navigateTo <| Route.CreateBigbitCodeIntroductionPage Nothing
+            )
+
+        Reset ->
+            ( init
+            , shared
+            , Route.navigateTo Route.CreateBigbitNamePage
+            )
+
+        AddFrame ->
+            let
+                currentPath =
+                    createBigbitPageCurrentActiveFile shared.route
+
+                newModel =
                     { model
-                        | tags = Util.addUniqueNonEmptyString tagName model.tags
-                        , tagInput = ""
+                        | highlightedComments =
+                            Array.push emptyHighlightCommentForCreate currentBigbitHighlightedComments
                     }
 
-            RemoveTag tagName ->
-                common.justSetModel { model | tags = List.filter (\tag -> tag /= tagName) model.tags }
+                newCmd =
+                    Route.navigateTo <|
+                        Route.CreateBigbitCodeFramePage (Array.length newModel.highlightedComments) currentPath
+            in
+            ( newModel, shared, newCmd )
 
-            OnUpdateIntroduction newIntro ->
-                common.justSetModel { model | introduction = newIntro }
+        RemoveFrame ->
+            if Array.length currentBigbitHighlightedComments == 1 then
+                common.doNothing
+            else
+                let
+                    newHighlightedComments =
+                        Array.slice
+                            0
+                            (Array.length currentBigbitHighlightedComments - 1)
+                            currentBigbitHighlightedComments
 
-            OnUpdateFrameComment frameNumber newComment ->
-                case Array.get (frameNumber - 1) currentBigbitHighlightedComments of
-                    Nothing ->
-                        common.doNothing
+                    newModel =
+                        { model | highlightedComments = newHighlightedComments }
 
-                    Just highlightedComment ->
-                        common.justSetModel
-                            { model
-                                | highlightedComments =
-                                    Array.set
-                                        (frameNumber - 1)
-                                        { highlightedComment | comment = newComment }
-                                        currentBigbitHighlightedComments
-                            }
+                    -- Have to make sure if they are on the last frame it pushes them down one frame.
+                    newRoute =
+                        case shared.route of
+                            Route.CreateBigbitCodeFramePage frameNumber filePath ->
+                                Just <|
+                                    Route.CreateBigbitCodeFramePage
+                                        (if frameNumber == Array.length currentBigbitHighlightedComments then
+                                            frameNumber - 1
+                                         else
+                                            frameNumber
+                                        )
+                                        filePath
 
-            OnUpdateConclusion newConclusion ->
-                common.justSetModel { model | conclusion = newConclusion }
+                            _ ->
+                                Nothing
 
-            UpdateActionButtonState newActionState ->
-                ( { model
+                    newCmd =
+                        maybeMapWithDefault Route.modifyTo Cmd.none newRoute
+                in
+                ( newModel, shared, newCmd )
+
+        ToggleFS ->
+            common.justSetModel { model | fs = Bigbit.toggleFS model.fs }
+
+        ToggleFolder folderPath ->
+            common.justSetModel { model | fs = Bigbit.toggleFSFolder folderPath model.fs }
+
+        SelectFile absolutePath ->
+            common.justProduceCmd <| Route.navigateToSameUrlWithFilePath (Just absolutePath) shared.route
+
+        TogglePreviewMarkdown ->
+            common.justUpdateModel togglePreviewMarkdown
+
+        AddFile absolutePath language ->
+            common.justSetModel <|
+                { model
+                    | fs =
+                        model.fs
+                            |> FS.addFile
+                                { overwriteExisting = False
+                                , forceCreateDirectories = Just <| always defaultEmptyFolder
+                                }
+                                absolutePath
+                                (FS.emptyFile { language = language })
+                            |> clearActionButtonInput
+                }
+
+        JumpToLineFromPreviousFrame filePath ->
+            case shared.route of
+                Route.CreateBigbitCodeFramePage frameNumber _ ->
+                    ( updateHCAtIndex
+                        model
+                        (frameNumber - 1)
+                        (\hcAtIndex -> { hcAtIndex | fileAndRange = Nothing })
+                    , shared
+                    , Route.modifyTo <| Route.CreateBigbitCodeFramePage frameNumber (Just filePath)
+                    )
+
+                _ ->
+                    common.doNothing
+
+        OnUpdateName newName ->
+            common.justSetModel { model | name = newName }
+
+        OnUpdateDescription newDescription ->
+            common.justSetModel { model | description = newDescription }
+
+        OnUpdateTagInput newTagInput ->
+            if String.endsWith " " newTagInput then
+                let
+                    newTag =
+                        String.dropRight 1 newTagInput
+
+                    newTags =
+                        Util.addUniqueNonEmptyString newTag model.tags
+                in
+                common.justSetModel
+                    { model
+                        | tags = newTags
+                        , tagInput = ""
+                    }
+            else
+                common.justSetModel { model | tagInput = newTagInput }
+
+        AddTag tagName ->
+            common.justSetModel
+                { model
+                    | tags = Util.addUniqueNonEmptyString tagName model.tags
+                    , tagInput = ""
+                }
+
+        RemoveTag tagName ->
+            common.justSetModel { model | tags = List.filter (\tag -> tag /= tagName) model.tags }
+
+        OnUpdateIntroduction newIntro ->
+            common.justSetModel { model | introduction = newIntro }
+
+        OnUpdateFrameComment frameNumber newComment ->
+            case Array.get (frameNumber - 1) currentBigbitHighlightedComments of
+                Nothing ->
+                    common.doNothing
+
+                Just highlightedComment ->
+                    common.justSetModel
+                        { model
+                            | highlightedComments =
+                                Array.set
+                                    (frameNumber - 1)
+                                    { highlightedComment | comment = newComment }
+                                    currentBigbitHighlightedComments
+                        }
+
+        OnUpdateConclusion newConclusion ->
+            common.justSetModel { model | conclusion = newConclusion }
+
+        UpdateActionButtonState newActionState ->
+            ( { model
+                | fs =
+                    model.fs
+                        |> FS.updateFSMetadata
+                            (\currentMetadata ->
+                                { currentMetadata
+                                    | actionButtonState =
+                                        if currentMetadata.actionButtonState == newActionState then
+                                            Nothing
+                                        else
+                                            newActionState
+                                    , actionButtonSubmitConfirmed = False
+                                }
+                            )
+              }
+            , shared
+            , Util.domFocus (always NoOp) "fs-action-input-box"
+            )
+
+        OnUpdateActionInput newActionButtonInput ->
+            common.justSetModel
+                { model
                     | fs =
                         model.fs
                             |> FS.updateFSMetadata
                                 (\currentMetadata ->
                                     { currentMetadata
-                                        | actionButtonState =
-                                            if currentMetadata.actionButtonState == newActionState then
-                                                Nothing
-                                            else
-                                                newActionState
+                                        | actionButtonInput = newActionButtonInput
                                         , actionButtonSubmitConfirmed = False
                                     }
                                 )
-                  }
-                , shared
-                , Util.domFocus (always NoOp) "fs-action-input-box"
-                )
+                }
 
-            OnUpdateActionInput newActionButtonInput ->
-                common.justSetModel
-                    { model
-                        | fs =
-                            model.fs
-                                |> FS.updateFSMetadata
-                                    (\currentMetadata ->
-                                        { currentMetadata
-                                            | actionButtonInput = newActionButtonInput
-                                            , actionButtonSubmitConfirmed = False
-                                        }
-                                    )
-                    }
+        SubmitActionInput ->
+            let
+                fs =
+                    model.fs
 
-            SubmitActionInput ->
-                let
-                    fs =
-                        model.fs
+                absolutePath =
+                    fs
+                        |> FS.getFSMetadata
+                        |> .actionButtonInput
 
-                    absolutePath =
-                        fs
-                            |> FS.getFSMetadata
-                            |> .actionButtonInput
+                maybeCurrentActionState =
+                    fs
+                        |> FS.getFSMetadata
+                        |> .actionButtonState
 
-                    maybeCurrentActionState =
-                        fs
-                            |> FS.getFSMetadata
-                            |> .actionButtonState
+                {- Filters the highlighted comments to make sure non of them point to non-existant files. Used
+                   when removing files/folders.
 
-                    {- Filters the highlighted comments to make sure non of them point to non-existant files. Used
-                       when removing files/folders.
+                   NOTE: If all comments are filtered out, adds a blank one because we always want at least one
+                         comment.
+                -}
+                getNewHighlightedComments hc newFS =
+                    Array.filter
+                        (\hc ->
+                            case hc.fileAndRange of
+                                Nothing ->
+                                    True
 
-                       NOTE: If all comments are filtered out, adds a blank one because we always want at least one
-                             comment.
-                    -}
-                    getNewHighlightedComments hc newFS =
-                        (Array.filter
-                            (\hc ->
-                                case hc.fileAndRange of
-                                    Nothing ->
-                                        True
-
-                                    Just { file, range } ->
-                                        FS.hasFile file newFS
-                            )
-                            currentBigbitHighlightedComments
+                                Just { file, range } ->
+                                    FS.hasFile file newFS
                         )
-                            |> (\remainingArray ->
-                                    if Array.length remainingArray == 0 then
-                                        Array.fromList
-                                            [ emptyHighlightCommentForCreate ]
-                                    else
-                                        remainingArray
-                               )
+                        currentBigbitHighlightedComments
+                        |> (\remainingArray ->
+                                if Array.length remainingArray == 0 then
+                                    Array.fromList
+                                        [ emptyHighlightCommentForCreate ]
+                                else
+                                    remainingArray
+                           )
 
-                    {- After removing files/folders the current URL can become invalid, this function redirects to
-                       intro if needed.
-                    -}
-                    navigateIfRouteNowInvalid newFS newHighlightedComments =
-                        let
-                            redirectToIntro =
-                                Route.modifyTo <| Route.CreateBigbitCodeIntroductionPage Nothing
+                {- After removing files/folders the current URL can become invalid, this function redirects to
+                   intro if needed.
+                -}
+                navigateIfRouteNowInvalid newFS newHighlightedComments =
+                    let
+                        redirectToIntro =
+                            Route.modifyTo <| Route.CreateBigbitCodeIntroductionPage Nothing
 
-                            redirectIfFileRemoved =
-                                case createBigbitPageCurrentActiveFile shared.route of
-                                    Nothing ->
+                        redirectIfFileRemoved =
+                            case createBigbitPageCurrentActiveFile shared.route of
+                                Nothing ->
+                                    Cmd.none
+
+                                Just filePath ->
+                                    if FS.hasFile filePath newFS then
                                         Cmd.none
-
-                                    Just filePath ->
-                                        if FS.hasFile filePath newFS then
-                                            Cmd.none
-                                        else
-                                            redirectToIntro
-                        in
-                            case shared.route of
-                                Route.CreateBigbitCodeFramePage frameNumber _ ->
-                                    if frameNumber > (Array.length newHighlightedComments) then
-                                        redirectToIntro
                                     else
-                                        redirectIfFileRemoved
+                                        redirectToIntro
+                    in
+                    case shared.route of
+                        Route.CreateBigbitCodeFramePage frameNumber _ ->
+                            if frameNumber > Array.length newHighlightedComments then
+                                redirectToIntro
+                            else
+                                redirectIfFileRemoved
 
-                                _ ->
-                                    redirectIfFileRemoved
+                        _ ->
+                            redirectIfFileRemoved
 
-                    ( newModel, newCmd ) =
-                        case maybeCurrentActionState of
-                            -- Should never happen.
-                            Nothing ->
-                                ( model, Cmd.none )
+                ( newModel, newCmd ) =
+                    case maybeCurrentActionState of
+                        -- Should never happen.
+                        Nothing ->
+                            ( model, Cmd.none )
 
-                            Just currentActionState ->
-                                case currentActionState of
-                                    AddingFile ->
-                                        case isValidAddFileInput absolutePath fs of
-                                            Err _ ->
-                                                ( model, Cmd.none )
+                        Just currentActionState ->
+                            case currentActionState of
+                                AddingFile ->
+                                    case isValidAddFileInput absolutePath fs of
+                                        Err _ ->
+                                            ( model, Cmd.none )
 
-                                            Ok language ->
+                                        Ok language ->
+                                            let
+                                                ( newModel, _, newCmd ) =
+                                                    update
+                                                        (commonSubPageUtil model shared)
+                                                        (AddFile absolutePath language)
+                                                        model
+                                                        shared
+                                            in
+                                            ( newModel, newCmd )
+
+                                AddingFolder ->
+                                    case isValidAddFolderInput absolutePath fs of
+                                        Err _ ->
+                                            ( model, Cmd.none )
+
+                                        Ok _ ->
+                                            ( { model
+                                                | fs =
+                                                    fs
+                                                        |> FS.addFolder
+                                                            { overwriteExisting = False
+                                                            , forceCreateDirectories =
+                                                                Just <| always defaultEmptyFolder
+                                                            }
+                                                            absolutePath
+                                                            (FS.Folder Dict.empty Dict.empty { isExpanded = True })
+                                                        |> clearActionButtonInput
+                                              }
+                                            , Cmd.none
+                                            )
+
+                                RemovingFile ->
+                                    case isValidRemoveFileInput absolutePath fs of
+                                        Err _ ->
+                                            ( model, Cmd.none )
+
+                                        Ok _ ->
+                                            if .actionButtonSubmitConfirmed <| FS.getFSMetadata fs then
                                                 let
-                                                    ( newModel, _, newCmd ) =
-                                                        update
-                                                            (commonSubPageUtil model shared)
-                                                            (AddFile absolutePath language)
-                                                            model
-                                                            shared
-                                                in
-                                                    ( newModel, newCmd )
-
-                                    AddingFolder ->
-                                        case isValidAddFolderInput absolutePath fs of
-                                            Err _ ->
-                                                ( model, Cmd.none )
-
-                                            Ok _ ->
-                                                ( { model
-                                                    | fs =
+                                                    newFS =
                                                         fs
-                                                            |> FS.addFolder
-                                                                { overwriteExisting = False
-                                                                , forceCreateDirectories =
-                                                                    Just <| always defaultEmptyFolder
-                                                                }
-                                                                absolutePath
-                                                                (FS.Folder Dict.empty Dict.empty { isExpanded = True })
+                                                            |> FS.removeFile absolutePath
                                                             |> clearActionButtonInput
+
+                                                    newHighlightedComments =
+                                                        getNewHighlightedComments
+                                                            currentBigbitHighlightedComments
+                                                            newFS
+                                                in
+                                                ( { model
+                                                    | fs = newFS
+                                                    , highlightedComments = newHighlightedComments
                                                   }
+                                                , navigateIfRouteNowInvalid newFS newHighlightedComments
+                                                )
+                                            else
+                                                ( { model | fs = fs |> setActionButtonSubmitConfirmed True }
                                                 , Cmd.none
                                                 )
 
-                                    RemovingFile ->
-                                        case isValidRemoveFileInput absolutePath fs of
-                                            Err _ ->
-                                                ( model, Cmd.none )
+                                RemovingFolder ->
+                                    case isValidRemoveFolderInput absolutePath fs of
+                                        Err _ ->
+                                            ( model, Cmd.none )
 
-                                            Ok _ ->
-                                                if .actionButtonSubmitConfirmed <| FS.getFSMetadata fs then
-                                                    let
-                                                        newFS =
-                                                            fs
-                                                                |> FS.removeFile absolutePath
-                                                                |> clearActionButtonInput
+                                        Ok _ ->
+                                            if .actionButtonSubmitConfirmed <| FS.getFSMetadata fs then
+                                                let
+                                                    newFS =
+                                                        fs
+                                                            |> FS.removeFolder absolutePath
+                                                            |> clearActionButtonInput
 
-                                                        newHighlightedComments =
-                                                            getNewHighlightedComments
-                                                                currentBigbitHighlightedComments
-                                                                newFS
-                                                    in
-                                                        ( { model
-                                                            | fs = newFS
-                                                            , highlightedComments = newHighlightedComments
-                                                          }
-                                                        , navigateIfRouteNowInvalid newFS newHighlightedComments
-                                                        )
-                                                else
-                                                    ( { model | fs = fs |> setActionButtonSubmitConfirmed True }
-                                                    , Cmd.none
-                                                    )
+                                                    newHighlightedComments =
+                                                        getNewHighlightedComments
+                                                            currentBigbitHighlightedComments
+                                                            newFS
+                                                in
+                                                ( { model
+                                                    | fs = newFS
+                                                    , highlightedComments = newHighlightedComments
+                                                  }
+                                                , navigateIfRouteNowInvalid newFS newHighlightedComments
+                                                )
+                                            else
+                                                ( { model | fs = fs |> setActionButtonSubmitConfirmed True }
+                                                , Cmd.none
+                                                )
+            in
+            ( newModel, shared, newCmd )
 
-                                    RemovingFolder ->
-                                        case isValidRemoveFolderInput absolutePath fs of
-                                            Err _ ->
-                                                ( model, Cmd.none )
+        Publish bigbit ->
+            let
+                publishBigbitAction =
+                    common.justProduceCmd <| common.api.post.createBigbit bigbit OnPublishFailure OnPublishSuccess
+            in
+            common.makeSingletonRequest RT.PublishBigbit publishBigbitAction
 
-                                            Ok _ ->
-                                                if .actionButtonSubmitConfirmed <| FS.getFSMetadata fs then
-                                                    let
-                                                        newFS =
-                                                            fs
-                                                                |> FS.removeFolder absolutePath
-                                                                |> clearActionButtonInput
+        OnPublishSuccess { targetID } ->
+            ( init
+            , { shared | userTidbits = Nothing }
+            , Route.navigateTo <| Route.ViewBigbitIntroductionPage Nothing targetID Nothing
+            )
+                |> common.andFinishRequest RT.PublishBigbit
 
-                                                        newHighlightedComments =
-                                                            getNewHighlightedComments
-                                                                currentBigbitHighlightedComments
-                                                                newFS
-                                                    in
-                                                        ( { model
-                                                            | fs = newFS
-                                                            , highlightedComments = newHighlightedComments
-                                                          }
-                                                        , navigateIfRouteNowInvalid newFS newHighlightedComments
-                                                        )
-                                                else
-                                                    ( { model | fs = fs |> setActionButtonSubmitConfirmed True }
-                                                    , Cmd.none
-                                                    )
-                in
-                    ( newModel, shared, newCmd )
-
-            Publish bigbit ->
-                let
-                    publishBigbitAction =
-                        common.justProduceCmd <| common.api.post.createBigbit bigbit OnPublishFailure OnPublishSuccess
-                in
-                    common.makeSingletonRequest RT.PublishBigbit publishBigbitAction
-
-            OnPublishSuccess { targetID } ->
-                ( init
-                , { shared | userTidbits = Nothing }
-                , Route.navigateTo <| Route.ViewBigbitIntroductionPage Nothing targetID Nothing
-                )
-                    |> common.andFinishRequest RT.PublishBigbit
-
-            OnPublishFailure apiError ->
-                common.justSetModalError apiError
-                    |> common.andFinishRequest RT.PublishBigbit
+        OnPublishFailure apiError ->
+            common.justSetModalError apiError
+                |> common.andFinishRequest RT.PublishBigbit

--- a/frontend/src/Pages/CreateBigbit/View.elm
+++ b/frontend/src/Pages/CreateBigbit/View.elm
@@ -8,8 +8,8 @@ import Dict
 import Elements.Simple.Editor as Editor
 import Elements.Simple.FileStructure as FS
 import Elements.Simple.Tags as Tags
-import Html exposing (Html, div, text, textarea, button, input, h1, h3, img, hr, i)
-import Html.Attributes exposing (class, classList, disabled, placeholder, value, hidden, id, src, style)
+import Html exposing (Html, button, div, h1, h3, hr, i, img, input, text, textarea)
+import Html.Attributes exposing (class, classList, disabled, hidden, id, placeholder, src, style, value)
 import Html.Events exposing (onClick, onInput)
 import Keyboard.Extra as KK
 import Models.Bigbit as Bigbit
@@ -345,18 +345,18 @@ view model shared =
                                                     else
                                                         Util.hiddenDiv
                                             in
-                                                case actionState of
-                                                    AddingFile ->
-                                                        showSubmitIconIf validFileInput True
+                                            case actionState of
+                                                AddingFile ->
+                                                    showSubmitIconIf validFileInput True
 
-                                                    AddingFolder ->
-                                                        showSubmitIconIf validFolderInput True
+                                                AddingFolder ->
+                                                    showSubmitIconIf validFolderInput True
 
-                                                    RemovingFile ->
-                                                        showSubmitIconIf validRemoveFileInput False
+                                                RemovingFile ->
+                                                    showSubmitIconIf validRemoveFileInput False
 
-                                                    RemovingFolder ->
-                                                        showSubmitIconIf validRemoveFolderInput False
+                                                RemovingFolder ->
+                                                    showSubmitIconIf validRemoveFolderInput False
                                     ]
                                 , button
                                     [ classList
@@ -400,18 +400,18 @@ view model shared =
                                     [ text "Remove Folder" ]
                                 ]
                     in
-                        div
-                            [ class "bigbit-fs" ]
-                            [ div [ hidden <| not fsOpen ] [ fs ]
-                            , i
-                                [ classList
-                                    [ ( "close-fs material-icons", True )
-                                    , ( "hidden", not fsOpen )
-                                    ]
-                                , onClick ToggleFS
+                    div
+                        [ class "bigbit-fs" ]
+                        [ div [ hidden <| not fsOpen ] [ fs ]
+                        , i
+                            [ classList
+                                [ ( "close-fs material-icons", True )
+                                , ( "hidden", not fsOpen )
                                 ]
-                                [ text "close" ]
+                            , onClick ToggleFS
                             ]
+                            [ text "close" ]
+                        ]
 
                 bigbitEditor =
                     div
@@ -464,21 +464,21 @@ view model shared =
                                                             newKeysDown =
                                                                 kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
                                                         in
-                                                            if key == KK.Tab then
-                                                                if newKeysDown == shared.keysDown then
-                                                                    Just NoOp
-                                                                else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                                    Just <|
-                                                                        GoTo <|
-                                                                            Route.CreateBigbitCodeFramePage
-                                                                                1
-                                                                                (getActiveFileForFrame 1 model)
-                                                                else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                                    Just <| GoTo <| Route.CreateBigbitTagsPage
-                                                                else
-                                                                    Nothing
+                                                        if key == KK.Tab then
+                                                            if newKeysDown == shared.keysDown then
+                                                                Just NoOp
+                                                            else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                                Just <|
+                                                                    GoTo <|
+                                                                        Route.CreateBigbitCodeFramePage
+                                                                            1
+                                                                            (getActiveFileForFrame 1 model)
+                                                            else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                                Just <| GoTo <| Route.CreateBigbitTagsPage
                                                             else
                                                                 Nothing
+                                                        else
+                                                            Nothing
                                                     )
                                                 ]
                                                 []
@@ -487,60 +487,59 @@ view model shared =
                                     Route.CreateBigbitCodeFramePage frameNumber _ ->
                                         let
                                             frameText =
-                                                (Array.get
+                                                Array.get
                                                     (frameNumber - 1)
                                                     model.highlightedComments
-                                                )
                                                     |> Maybe.map .comment
                                                     |> Maybe.withDefault ""
                                         in
-                                            Util.markdownOr
-                                                markdownOpen
-                                                frameText
-                                                (textarea
-                                                    [ placeholder <|
-                                                        "Frame "
-                                                            ++ (toString frameNumber)
-                                                            ++ "\n\n"
-                                                            ++ "Highlight a chunk of code and explain it..."
-                                                    , id "frame-input"
-                                                    , onInput <| OnUpdateFrameComment frameNumber
-                                                    , value frameText
-                                                    , Util.onKeydownPreventDefault
-                                                        (\key ->
-                                                            let
-                                                                newKeysDown =
-                                                                    kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
-                                                            in
-                                                                if key == KK.Tab then
-                                                                    if newKeysDown == shared.keysDown then
-                                                                        Just NoOp
-                                                                    else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                                        Just <|
-                                                                            GoTo <|
-                                                                                Route.CreateBigbitCodeFramePage
-                                                                                    (frameNumber + 1)
-                                                                                    (getActiveFileForFrame
-                                                                                        (frameNumber + 1)
-                                                                                        model
-                                                                                    )
-                                                                    else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                                        Just <|
-                                                                            GoTo <|
-                                                                                Route.CreateBigbitCodeFramePage
-                                                                                    (frameNumber - 1)
-                                                                                    (getActiveFileForFrame
-                                                                                        (frameNumber - 1)
-                                                                                        model
-                                                                                    )
-                                                                    else
-                                                                        Nothing
-                                                                else
-                                                                    Nothing
-                                                        )
-                                                    ]
-                                                    []
-                                                )
+                                        Util.markdownOr
+                                            markdownOpen
+                                            frameText
+                                            (textarea
+                                                [ placeholder <|
+                                                    "Frame "
+                                                        ++ toString frameNumber
+                                                        ++ "\n\n"
+                                                        ++ "Highlight a chunk of code and explain it..."
+                                                , id "frame-input"
+                                                , onInput <| OnUpdateFrameComment frameNumber
+                                                , value frameText
+                                                , Util.onKeydownPreventDefault
+                                                    (\key ->
+                                                        let
+                                                            newKeysDown =
+                                                                kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
+                                                        in
+                                                        if key == KK.Tab then
+                                                            if newKeysDown == shared.keysDown then
+                                                                Just NoOp
+                                                            else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                                Just <|
+                                                                    GoTo <|
+                                                                        Route.CreateBigbitCodeFramePage
+                                                                            (frameNumber + 1)
+                                                                            (getActiveFileForFrame
+                                                                                (frameNumber + 1)
+                                                                                model
+                                                                            )
+                                                            else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                                Just <|
+                                                                    GoTo <|
+                                                                        Route.CreateBigbitCodeFramePage
+                                                                            (frameNumber - 1)
+                                                                            (getActiveFileForFrame
+                                                                                (frameNumber - 1)
+                                                                                model
+                                                                            )
+                                                            else
+                                                                Nothing
+                                                        else
+                                                            Nothing
+                                                    )
+                                                ]
+                                                []
+                                            )
 
                                     Route.CreateBigbitCodeConclusionPage _ ->
                                         Util.markdownOr
@@ -557,24 +556,24 @@ view model shared =
                                                             newKeysDown =
                                                                 kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
                                                         in
-                                                            if key == KK.Tab then
-                                                                if newKeysDown == shared.keysDown then
-                                                                    Just NoOp
-                                                                else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                                    Just <| NoOp
-                                                                else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                                    Just <|
-                                                                        GoTo <|
-                                                                            Route.CreateBigbitCodeFramePage
+                                                        if key == KK.Tab then
+                                                            if newKeysDown == shared.keysDown then
+                                                                Just NoOp
+                                                            else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                                Just <| NoOp
+                                                            else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                                Just <|
+                                                                    GoTo <|
+                                                                        Route.CreateBigbitCodeFramePage
+                                                                            (Array.length model.highlightedComments)
+                                                                            (getActiveFileForFrame
                                                                                 (Array.length model.highlightedComments)
-                                                                                (getActiveFileForFrame
-                                                                                    (Array.length model.highlightedComments)
-                                                                                    model
-                                                                                )
-                                                                else
-                                                                    Nothing
+                                                                                model
+                                                                            )
                                                             else
                                                                 Nothing
+                                                        else
+                                                            Nothing
                                                     )
                                                 ]
                                                 []
@@ -590,7 +589,7 @@ view model shared =
                                 dynamicFrameButtons =
                                     div
                                         [ class "frame-buttons-box" ]
-                                        ((Array.indexedMap
+                                        (Array.indexedMap
                                             (\index highlightedComment ->
                                                 button
                                                     [ classList [ ( "selected-frame", (Just <| index + 1) == frameTab ) ]
@@ -606,179 +605,178 @@ view model shared =
                                                     [ text <| toString <| index + 1 ]
                                             )
                                             model.highlightedComments
-                                         )
                                             |> Array.toList
                                         )
                             in
-                                div
-                                    [ class "comment-body-bottom-buttons"
-                                    , hidden markdownOpen
-                                    ]
-                                    [ button
-                                        [ onClick <| GoTo <| Route.CreateBigbitCodeIntroductionPage Nothing
-                                        , classList
-                                            [ ( "introduction-button", True )
-                                            , ( "selected-frame", introTab )
-                                            ]
-                                        ]
-                                        [ text "Introduction" ]
-                                    , button
-                                        [ onClick <| GoTo <| Route.CreateBigbitCodeConclusionPage Nothing
-                                        , classList
-                                            [ ( "conclusion-button", True )
-                                            , ( "selected-frame", conclusionTab )
-                                            ]
-                                        ]
-                                        [ text "Conclusion" ]
-                                    , button
-                                        [ class "add-or-remove-frame-button"
-                                        , onClick <| AddFrame
-                                        ]
-                                        [ text "+" ]
-                                    , button
-                                        [ class "add-or-remove-frame-button"
-                                        , onClick <| RemoveFrame
-                                        , disabled <|
-                                            Array.length model.highlightedComments
-                                                <= 1
-                                        ]
-                                        [ text "-" ]
-                                    , hr [] []
-                                    , dynamicFrameButtons
-                                    ]
-                    in
-                        div
-                            []
-                            [ div
-                                [ class "comment-creator" ]
-                                [ body
-                                , tabBar
+                            div
+                                [ class "comment-body-bottom-buttons"
+                                , hidden markdownOpen
                                 ]
+                                [ button
+                                    [ onClick <| GoTo <| Route.CreateBigbitCodeIntroductionPage Nothing
+                                    , classList
+                                        [ ( "introduction-button", True )
+                                        , ( "selected-frame", introTab )
+                                        ]
+                                    ]
+                                    [ text "Introduction" ]
+                                , button
+                                    [ onClick <| GoTo <| Route.CreateBigbitCodeConclusionPage Nothing
+                                    , classList
+                                        [ ( "conclusion-button", True )
+                                        , ( "selected-frame", conclusionTab )
+                                        ]
+                                    ]
+                                    [ text "Conclusion" ]
+                                , button
+                                    [ class "add-or-remove-frame-button"
+                                    , onClick <| AddFrame
+                                    ]
+                                    [ text "+" ]
+                                , button
+                                    [ class "add-or-remove-frame-button"
+                                    , onClick <| RemoveFrame
+                                    , disabled <|
+                                        Array.length model.highlightedComments
+                                            <= 1
+                                    ]
+                                    [ text "-" ]
+                                , hr [] []
+                                , dynamicFrameButtons
+                                ]
+                    in
+                    div
+                        []
+                        [ div
+                            [ class "comment-creator" ]
+                            [ body
+                            , tabBar
                             ]
+                        ]
             in
-                div
-                    [ class "create-bigbit-code" ]
-                    [ div
-                        [ class "bigbit-extended-view" ]
-                        [ bigbitFS
-                        , bigbitEditor
-                        , bigbitCommentBox
-                        ]
+            div
+                [ class "create-bigbit-code" ]
+                [ div
+                    [ class "bigbit-extended-view" ]
+                    [ bigbitFS
+                    , bigbitEditor
+                    , bigbitCommentBox
                     ]
+                ]
     in
-        div
-            [ classList
-                [ ( "create-bigbit", True )
-                , ( "fs-closed", not fsOpen )
-                , ( "viewing-fs-open"
-                  , case shared.route of
-                        Route.CreateBigbitCodeIntroductionPage _ ->
-                            fsOpen
+    div
+        [ classList
+            [ ( "create-bigbit", True )
+            , ( "fs-closed", not fsOpen )
+            , ( "viewing-fs-open"
+              , case shared.route of
+                    Route.CreateBigbitCodeIntroductionPage _ ->
+                        fsOpen
 
-                        Route.CreateBigbitCodeFramePage _ _ ->
-                            fsOpen
+                    Route.CreateBigbitCodeFramePage _ _ ->
+                        fsOpen
 
-                        Route.CreateBigbitCodeConclusionPage _ ->
-                            fsOpen
+                    Route.CreateBigbitCodeConclusionPage _ ->
+                        fsOpen
 
-                        _ ->
-                            False
-                  )
-                ]
+                    _ ->
+                        False
+              )
             ]
-            [ div
-                [ class "sub-bar" ]
-                [ button
-                    [ class "sub-bar-button"
-                    , onClick <| Reset
-                    ]
-                    [ text "Reset" ]
-                , case previousFrameRange model shared.route of
-                    Nothing ->
-                        Util.hiddenDiv
-
-                    Just ( filePath, _ ) ->
-                        button
-                            [ class "sub-bar-button previous-frame-location"
-                            , onClick <| JumpToLineFromPreviousFrame filePath
-                            ]
-                            [ text "Previous Frame Location" ]
-                , publishButton
+        ]
+        [ div
+            [ class "sub-bar" ]
+            [ button
+                [ class "sub-bar-button"
+                , onClick <| Reset
                 ]
-            , createBigbitNavbar
-            , case shared.route of
-                Route.CreateBigbitNamePage ->
-                    div
-                        [ class "create-bigbit-name" ]
-                        [ input
-                            [ placeholder "Name"
-                            , id "name-input"
-                            , onInput OnUpdateName
-                            , value model.name
-                            , Util.onKeydownPreventDefault
-                                (\key ->
-                                    if key == KK.Tab then
-                                        Just NoOp
-                                    else
-                                        Nothing
-                                )
-                            ]
-                            []
-                        , Util.limitCharsText 50 model.name
-                        ]
-
-                Route.CreateBigbitDescriptionPage ->
-                    div
-                        [ class "create-bigbit-description" ]
-                        [ textarea
-                            [ placeholder "Description"
-                            , id "description-input"
-                            , onInput OnUpdateDescription
-                            , value model.description
-                            , Util.onKeydownPreventDefault
-                                (\key ->
-                                    if key == KK.Tab then
-                                        Just NoOp
-                                    else
-                                        Nothing
-                                )
-                            ]
-                            []
-                        , Util.limitCharsText 300 model.description
-                        ]
-
-                Route.CreateBigbitTagsPage ->
-                    div
-                        [ class "create-tidbit-tags" ]
-                        [ input
-                            [ placeholder "Tags"
-                            , id "tags-input"
-                            , onInput OnUpdateTagInput
-                            , value model.tagInput
-                            , Util.onKeydownPreventDefault
-                                (\key ->
-                                    if key == KK.Enter then
-                                        Just <| AddTag model.tagInput
-                                    else if key == KK.Tab then
-                                        Just <| NoOp
-                                    else
-                                        Nothing
-                                )
-                            ]
-                            []
-                        , Tags.view RemoveTag model.tags
-                        ]
-
-                Route.CreateBigbitCodeIntroductionPage _ ->
-                    bigbitCodeTab
-
-                Route.CreateBigbitCodeFramePage frameNumber _ ->
-                    bigbitCodeTab
-
-                Route.CreateBigbitCodeConclusionPage _ ->
-                    bigbitCodeTab
-
-                -- Should never happen
-                _ ->
+                [ text "Reset" ]
+            , case previousFrameRange model shared.route of
+                Nothing ->
                     Util.hiddenDiv
+
+                Just ( filePath, _ ) ->
+                    button
+                        [ class "sub-bar-button previous-frame-location"
+                        , onClick <| JumpToLineFromPreviousFrame filePath
+                        ]
+                        [ text "Previous Frame Location" ]
+            , publishButton
             ]
+        , createBigbitNavbar
+        , case shared.route of
+            Route.CreateBigbitNamePage ->
+                div
+                    [ class "create-bigbit-name" ]
+                    [ input
+                        [ placeholder "Name"
+                        , id "name-input"
+                        , onInput OnUpdateName
+                        , value model.name
+                        , Util.onKeydownPreventDefault
+                            (\key ->
+                                if key == KK.Tab then
+                                    Just NoOp
+                                else
+                                    Nothing
+                            )
+                        ]
+                        []
+                    , Util.limitCharsText 50 model.name
+                    ]
+
+            Route.CreateBigbitDescriptionPage ->
+                div
+                    [ class "create-bigbit-description" ]
+                    [ textarea
+                        [ placeholder "Description"
+                        , id "description-input"
+                        , onInput OnUpdateDescription
+                        , value model.description
+                        , Util.onKeydownPreventDefault
+                            (\key ->
+                                if key == KK.Tab then
+                                    Just NoOp
+                                else
+                                    Nothing
+                            )
+                        ]
+                        []
+                    , Util.limitCharsText 300 model.description
+                    ]
+
+            Route.CreateBigbitTagsPage ->
+                div
+                    [ class "create-tidbit-tags" ]
+                    [ input
+                        [ placeholder "Tags"
+                        , id "tags-input"
+                        , onInput OnUpdateTagInput
+                        , value model.tagInput
+                        , Util.onKeydownPreventDefault
+                            (\key ->
+                                if key == KK.Enter then
+                                    Just <| AddTag model.tagInput
+                                else if key == KK.Tab then
+                                    Just <| NoOp
+                                else
+                                    Nothing
+                            )
+                        ]
+                        []
+                    , Tags.view RemoveTag model.tags
+                    ]
+
+            Route.CreateBigbitCodeIntroductionPage _ ->
+                bigbitCodeTab
+
+            Route.CreateBigbitCodeFramePage frameNumber _ ->
+                bigbitCodeTab
+
+            Route.CreateBigbitCodeConclusionPage _ ->
+                bigbitCodeTab
+
+            -- Should never happen
+            _ ->
+                Util.hiddenDiv
+        ]

--- a/frontend/src/Pages/CreateSnipbit/Init.elm
+++ b/frontend/src/Pages/CreateSnipbit/Init.elm
@@ -12,7 +12,7 @@ init : Model
 init =
     { language = Nothing
     , languageQueryACState = AC.empty
-    , languageListHowManyToShow = (List.length humanReadableListOfLanguages)
+    , languageListHowManyToShow = List.length humanReadableListOfLanguages
     , languageQuery = ""
     , name = ""
     , description = ""

--- a/frontend/src/Pages/CreateSnipbit/JSON.elm
+++ b/frontend/src/Pages/CreateSnipbit/JSON.elm
@@ -6,7 +6,7 @@ import DefaultServices.Util as Util
 import JSON.Language
 import JSON.Snipbit
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.CreateSnipbit.Model exposing (..)
 

--- a/frontend/src/Pages/CreateSnipbit/Model.elm
+++ b/frontend/src/Pages/CreateSnipbit/Model.elm
@@ -6,7 +6,7 @@ import DefaultServices.Util as Util
 import Elements.Simple.Editor as Editor exposing (Language)
 import Models.Range as Range
 import Models.Route as Route
-import Models.Snipbit exposing (MaybeHighlightedComment, HighlightedComment)
+import Models.Snipbit exposing (HighlightedComment, MaybeHighlightedComment)
 
 
 {-| `CreateSnipbit` model.
@@ -89,22 +89,21 @@ conclusionFilledIn =
 highlightedCommentsFilledIn : Model -> Maybe (Array.Array HighlightedComment)
 highlightedCommentsFilledIn =
     .highlightedComments
-        >> (Array.foldr
-                (\maybeHC previousHC ->
-                    case ( maybeHC.range, maybeHC.comment ) of
-                        ( Just aRange, Just aComment ) ->
-                            if (String.length aComment > 0) && (not <| Range.isEmptyRange aRange) then
-                                Maybe.map
-                                    ((::) { range = aRange, comment = aComment })
-                                    previousHC
-                            else
-                                Nothing
-
-                        _ ->
+        >> Array.foldr
+            (\maybeHC previousHC ->
+                case ( maybeHC.range, maybeHC.comment ) of
+                    ( Just aRange, Just aComment ) ->
+                        if (String.length aComment > 0) && (not <| Range.isEmptyRange aRange) then
+                            Maybe.map
+                                ((::) { range = aRange, comment = aComment })
+                                previousHC
+                        else
                             Nothing
-                )
-                (Just [])
-           )
+
+                    _ ->
+                        Nothing
+            )
+            (Just [])
         >> Maybe.map Array.fromList
 
 
@@ -167,7 +166,7 @@ filterLanguagesByQuery query =
         containsQuery =
             String.toLower >> String.contains (String.toLower query)
     in
-        List.filter
-            (\langPair ->
-                (containsQuery <| Tuple.second langPair) || (containsQuery <| toString <| Tuple.first langPair)
-            )
+    List.filter
+        (\langPair ->
+            (containsQuery <| Tuple.second langPair) || (containsQuery <| toString <| Tuple.first langPair)
+        )

--- a/frontend/src/Pages/CreateSnipbit/Update.elm
+++ b/frontend/src/Pages/CreateSnipbit/Update.elm
@@ -4,7 +4,7 @@ import Array
 import Autocomplete as AC
 import DefaultServices.ArrayExtra as ArrayExtra
 import DefaultServices.CommonSubPageUtil exposing (CommonSubPageUtil(..), commonSubPageUtil)
-import DefaultServices.Util as Util exposing (togglePreviewMarkdown, maybeMapWithDefault)
+import DefaultServices.Util as Util exposing (maybeMapWithDefault, togglePreviewMarkdown)
 import Elements.Simple.Editor as Editor
 import JSON.Language
 import Json.Decode as Decode
@@ -27,413 +27,413 @@ update (Common common) msg model shared =
         currentHighlightedComments =
             model.highlightedComments
     in
-        case msg of
-            NoOp ->
-                common.doNothing
+    case msg of
+        NoOp ->
+            common.doNothing
 
-            GoTo route ->
-                common.justProduceCmd <| Route.navigateTo route
+        GoTo route ->
+            common.justProduceCmd <| Route.navigateTo route
 
-            OnRouteHit route ->
-                let
-                    createCreateSnipbitEditor aceRange =
+        OnRouteHit route ->
+            let
+                createCreateSnipbitEditor aceRange =
+                    let
+                        aceLang =
+                            maybeMapWithDefault
+                                Editor.aceLanguageLocation
+                                ""
+                                model.language
+                    in
+                    Cmd.batch
+                        [ Ports.createCodeEditor
+                            { id = "create-snipbit-code-editor"
+                            , fileID = ""
+                            , lang = aceLang
+                            , theme = User.getTheme shared.user
+                            , value = model.code
+                            , range = aceRange
+                            , useMarker = False
+                            , readOnly = False
+                            , selectAllowed = True
+                            }
+                        , Ports.smoothScrollToBottom
+                        ]
+
+                focusOn theID =
+                    common.justProduceCmd <| Util.domFocus (\_ -> NoOp) theID
+            in
+            case route of
+                Route.CreateSnipbitNamePage ->
+                    focusOn "name-input"
+
+                Route.CreateSnipbitDescriptionPage ->
+                    focusOn "description-input"
+
+                Route.CreateSnipbitLanguagePage ->
+                    focusOn "language-query-input"
+
+                Route.CreateSnipbitTagsPage ->
+                    focusOn "tags-input"
+
+                Route.CreateSnipbitCodeIntroductionPage ->
+                    common.justProduceCmd <|
+                        Cmd.batch
+                            [ createCreateSnipbitEditor Nothing
+                            , Util.domFocus (\_ -> NoOp) "introduction-input"
+                            ]
+
+                Route.CreateSnipbitCodeFramePage frameNumber ->
+                    let
+                        -- 0 based indexing.
+                        frameIndex =
+                            frameNumber - 1
+
+                        frameIndexTooHigh =
+                            frameIndex >= Array.length model.highlightedComments
+
+                        frameIndexTooLow =
+                            frameIndex < 0
+                    in
+                    if frameIndexTooLow then
+                        common.justProduceCmd <| Route.modifyTo Route.CreateSnipbitCodeIntroductionPage
+                    else if frameIndexTooHigh then
+                        common.justProduceCmd <| Route.modifyTo Route.CreateSnipbitCodeConclusionPage
+                    else
                         let
-                            aceLang =
-                                maybeMapWithDefault
-                                    Editor.aceLanguageLocation
-                                    ""
-                                    model.language
+                            -- Either the existing range, the range from
+                            -- the previous frame collapsed, or Nothing.
+                            newHCRange =
+                                Array.get frameIndex model.highlightedComments
+                                    |> Maybe.andThen .range
+                                    |> (\maybeRange ->
+                                            case maybeRange of
+                                                Nothing ->
+                                                    previousFrameRange model shared.route
+                                                        |> Maybe.map Range.collapseRange
+
+                                                Just range ->
+                                                    Just range
+                                       )
                         in
-                            Cmd.batch
-                                [ Ports.createCodeEditor
-                                    { id = "create-snipbit-code-editor"
-                                    , fileID = ""
-                                    , lang = aceLang
-                                    , theme = User.getTheme shared.user
-                                    , value = model.code
-                                    , range = aceRange
-                                    , useMarker = False
-                                    , readOnly = False
-                                    , selectAllowed = True
-                                    }
-                                , Ports.smoothScrollToBottom
-                                ]
-
-                    focusOn theID =
-                        common.justProduceCmd <| Util.domFocus (\_ -> NoOp) theID
-                in
-                    case route of
-                        Route.CreateSnipbitNamePage ->
-                            focusOn "name-input"
-
-                        Route.CreateSnipbitDescriptionPage ->
-                            focusOn "description-input"
-
-                        Route.CreateSnipbitLanguagePage ->
-                            focusOn "language-query-input"
-
-                        Route.CreateSnipbitTagsPage ->
-                            focusOn "tags-input"
-
-                        Route.CreateSnipbitCodeIntroductionPage ->
-                            common.justProduceCmd <|
-                                Cmd.batch
-                                    [ createCreateSnipbitEditor Nothing
-                                    , Util.domFocus (\_ -> NoOp) "introduction-input"
-                                    ]
-
-                        Route.CreateSnipbitCodeFramePage frameNumber ->
-                            let
-                                -- 0 based indexing.
-                                frameIndex =
-                                    frameNumber - 1
-
-                                frameIndexTooHigh =
-                                    frameIndex >= (Array.length model.highlightedComments)
-
-                                frameIndexTooLow =
-                                    frameIndex < 0
-                            in
-                                if frameIndexTooLow then
-                                    common.justProduceCmd <| Route.modifyTo Route.CreateSnipbitCodeIntroductionPage
-                                else if frameIndexTooHigh then
-                                    common.justProduceCmd <| Route.modifyTo Route.CreateSnipbitCodeConclusionPage
-                                else
-                                    let
-                                        -- Either the existing range, the range from
-                                        -- the previous frame collapsed, or Nothing.
-                                        newHCRange =
-                                            (Array.get frameIndex model.highlightedComments)
-                                                |> Maybe.andThen .range
-                                                |> (\maybeRange ->
-                                                        case maybeRange of
-                                                            Nothing ->
-                                                                previousFrameRange model shared.route
-                                                                    |> Maybe.map Range.collapseRange
-
-                                                            Just range ->
-                                                                Just range
-                                                   )
-                                    in
-                                        ( { model
-                                            | highlightedComments =
-                                                ArrayExtra.update
-                                                    frameIndex
-                                                    (\currentHC -> { currentHC | range = newHCRange })
-                                                    model.highlightedComments
-                                          }
-                                        , shared
-                                        , Cmd.batch
-                                            [ createCreateSnipbitEditor newHCRange
-                                            , Util.domFocus (\_ -> NoOp) "frame-input"
-                                            ]
-                                        )
-
-                        Route.CreateSnipbitCodeConclusionPage ->
-                            common.justProduceCmd <|
-                                Cmd.batch
-                                    [ createCreateSnipbitEditor Nothing
-                                    , Util.domFocus (\_ -> NoOp) "conclusion-input"
-                                    ]
-
-                        _ ->
-                            common.doNothing
-
-            OnRangeSelected newRange ->
-                case shared.route of
-                    Route.CreateSnipbitCodeIntroductionPage ->
-                        common.doNothing
-
-                    Route.CreateSnipbitCodeConclusionPage ->
-                        common.doNothing
-
-                    Route.CreateSnipbitCodeFramePage frameNumber ->
-                        let
-                            frameIndex =
-                                frameNumber - 1
-                        in
-                            case (Array.get frameIndex currentHighlightedComments) of
-                                Nothing ->
-                                    common.doNothing
-
-                                Just currentFrameHighlightedComment ->
-                                    let
-                                        newFrame =
-                                            { currentFrameHighlightedComment | range = Just newRange }
-
-                                        newHighlightedComments =
-                                            Array.set frameIndex newFrame currentHighlightedComments
-                                    in
-                                        common.justSetModel { model | highlightedComments = newHighlightedComments }
-
-                    -- Should never happen (highlighting when not on the editor pages).
-                    _ ->
-                        common.doNothing
-
-            OnUpdateACState acMsg ->
-                let
-                    ( newACState, maybeMsg ) =
-                        AC.update
-                            acUpdateConfig
-                            acMsg
-                            model.languageListHowManyToShow
-                            model.languageQueryACState
-                            (filterLanguagesByQuery
-                                model.languageQuery
-                                shared.languages
-                            )
-
-                    newModel =
-                        { model | languageQueryACState = newACState }
-                in
-                    case maybeMsg of
-                        Nothing ->
-                            common.justSetModel newModel
-
-                        Just updateMsg ->
-                            update (commonSubPageUtil newModel shared) updateMsg newModel shared
-
-            OnUpdateACWrap toTop ->
-                common.justSetModel
-                    { model
-                        | languageQueryACState =
-                            (if toTop then
-                                AC.resetToLastItem
-                             else
-                                AC.resetToFirstItem
-                            )
-                                acUpdateConfig
-                                (filterLanguagesByQuery model.languageQuery shared.languages)
-                                model.languageListHowManyToShow
-                                model.languageQueryACState
-                    }
-
-            -- On top of updating the code, we need to check that no highlights are now out of range. If highlights are
-            -- now out of range we minimize them to the greatest size they can be whilst still being in range.
-            OnUpdateCode { newCode, action, deltaRange } ->
-                let
-                    currentCode =
-                        model.code
-
-                    newHighlightedComments =
-                        Array.map
-                            (\comment ->
-                                case comment.range of
-                                    Nothing ->
-                                        comment
-
-                                    Just aRange ->
-                                        { comment
-                                            | range =
-                                                Just <|
-                                                    Range.getNewRangeAfterDelta
-                                                        currentCode
-                                                        newCode
-                                                        action
-                                                        deltaRange
-                                                        aRange
-                                        }
-                            )
-                            currentHighlightedComments
-                in
-                    common.justSetModel
-                        { model
-                            | code = newCode
-                            , highlightedComments = newHighlightedComments
-                        }
-
-            GoToCodeTab ->
-                ( { model | previewMarkdown = False }
-                , shared
-                , Route.navigateTo Route.CreateSnipbitCodeIntroductionPage
-                )
-
-            Reset ->
-                ( init, shared, Route.navigateTo Route.CreateSnipbitNamePage )
-
-            AddFrame ->
-                let
-                    newModel =
-                        { model
-                            | highlightedComments =
-                                (Array.push { range = Nothing, comment = Nothing } currentHighlightedComments)
-                        }
-
-                    newMsg =
-                        GoTo <| Route.CreateSnipbitCodeFramePage <| Array.length newModel.highlightedComments
-                in
-                    update (commonSubPageUtil newModel shared) newMsg newModel shared
-
-            RemoveFrame ->
-                let
-                    newHighlightedComments =
-                        Array.slice 0 (Array.length currentHighlightedComments - 1) currentHighlightedComments
-
-                    newModel =
-                        { model | highlightedComments = newHighlightedComments }
-                in
-                    case shared.route of
-                        Route.CreateSnipbitCodeIntroductionPage ->
-                            common.justSetModel newModel
-
-                        Route.CreateSnipbitCodeConclusionPage ->
-                            common.justSetModel newModel
-
-                        -- We need to go "down" a tab if the user was on the last tab and they removed a tab.
-                        Route.CreateSnipbitCodeFramePage frameNumber ->
-                            let
-                                frameIndex =
-                                    frameNumber - 1
-                            in
-                                if frameIndex >= (Array.length newHighlightedComments) then
-                                    update
-                                        (commonSubPageUtil newModel shared)
-                                        (GoTo <|
-                                            Route.CreateSnipbitCodeFramePage <|
-                                                Array.length newHighlightedComments
-                                        )
-                                        newModel
-                                        shared
-                                else
-                                    common.justSetModel newModel
-
-                        -- Should never happen.
-                        _ ->
-                            common.justSetModel newModel
-
-            TogglePreviewMarkdown ->
-                common.justSetModel <| Util.togglePreviewMarkdown model
-
-            JumpToLineFromPreviousFrame ->
-                case shared.route of
-                    Route.CreateSnipbitCodeFramePage frameNumber ->
                         ( { model
                             | highlightedComments =
                                 ArrayExtra.update
-                                    (frameNumber - 1)
-                                    (\hc -> { hc | range = Nothing })
+                                    frameIndex
+                                    (\currentHC -> { currentHC | range = newHCRange })
                                     model.highlightedComments
                           }
                         , shared
-                        , Route.modifyTo shared.route
+                        , Cmd.batch
+                            [ createCreateSnipbitEditor newHCRange
+                            , Util.domFocus (\_ -> NoOp) "frame-input"
+                            ]
                         )
 
-                    _ ->
-                        common.doNothing
+                Route.CreateSnipbitCodeConclusionPage ->
+                    common.justProduceCmd <|
+                        Cmd.batch
+                            [ createCreateSnipbitEditor Nothing
+                            , Util.domFocus (\_ -> NoOp) "conclusion-input"
+                            ]
 
-            OnUpdateLanguageQuery newLanguageQuery ->
-                common.justSetModel { model | languageQuery = newLanguageQuery }
+                _ ->
+                    common.doNothing
 
-            SelectLanguage maybeEncodedLang ->
-                let
-                    language =
-                        case maybeEncodedLang of
-                            -- Erasing the selected language.
-                            Nothing ->
-                                Nothing
+        OnRangeSelected newRange ->
+            case shared.route of
+                Route.CreateSnipbitCodeIntroductionPage ->
+                    common.doNothing
 
-                            -- Selecting a language.
-                            Just encodedLang ->
-                                Util.quote
-                                    >> Decode.decodeString JSON.Language.decoder
-                                    >> Result.toMaybe
-                                <|
-                                    encodedLang
+                Route.CreateSnipbitCodeConclusionPage ->
+                    common.doNothing
 
-                    -- If the user wants to select a new language, we help them by focussing the input box.
-                    newCmd =
-                        if Util.isNothing language then
-                            Util.domFocus (always NoOp) "language-query-input"
-                        else
-                            Cmd.none
-
-                    newLanguageQuery =
-                        case language of
-                            Nothing ->
-                                ""
-
-                            Just aLanguage ->
-                                Editor.getHumanReadableName aLanguage
-
-                    newModel =
-                        { model
-                            | language = language
-                            , languageQuery = newLanguageQuery
-                        }
-                in
-                    ( newModel, shared, newCmd )
-
-            OnUpdateName newName ->
-                common.justSetModel { model | name = newName }
-
-            OnUpdateDescription newDescription ->
-                common.justSetModel { model | description = newDescription }
-
-            OnUpdateTagInput newTagInput ->
-                if String.endsWith " " newTagInput then
+                Route.CreateSnipbitCodeFramePage frameNumber ->
                     let
-                        newTag =
-                            String.dropRight 1 newTagInput
-
-                        newTags =
-                            Util.addUniqueNonEmptyString newTag model.tags
+                        frameIndex =
+                            frameNumber - 1
                     in
-                        common.justSetModel
-                            { model
-                                | tagInput = ""
-                                , tags = newTags
-                            }
-                else
-                    common.justSetModel { model | tagInput = newTagInput }
+                    case Array.get frameIndex currentHighlightedComments of
+                        Nothing ->
+                            common.doNothing
 
-            RemoveTag tagName ->
-                common.justSetModel { model | tags = List.filter (\aTag -> aTag /= tagName) model.tags }
+                        Just currentFrameHighlightedComment ->
+                            let
+                                newFrame =
+                                    { currentFrameHighlightedComment | range = Just newRange }
 
-            AddTag tagName ->
-                common.justSetModel
-                    { model
-                        | tags = Util.addUniqueNonEmptyString tagName model.tags
-                        , tagInput = ""
-                    }
-
-            OnUpdateFrameComment index newComment ->
-                case Array.get index currentHighlightedComments of
-                    Nothing ->
-                        common.doNothing
-
-                    Just highlightComment ->
-                        let
-                            newHighlightComment =
-                                { highlightComment | comment = Just newComment }
-
-                            newHighlightedComments =
-                                Array.set index newHighlightComment currentHighlightedComments
-                        in
+                                newHighlightedComments =
+                                    Array.set frameIndex newFrame currentHighlightedComments
+                            in
                             common.justSetModel { model | highlightedComments = newHighlightedComments }
 
-            OnUpdateIntroduction newIntro ->
-                common.justSetModel { model | introduction = newIntro }
+                -- Should never happen (highlighting when not on the editor pages).
+                _ ->
+                    common.doNothing
 
-            OnUpdateConclusion newConclusion ->
-                common.justSetModel { model | conclusion = newConclusion }
+        OnUpdateACState acMsg ->
+            let
+                ( newACState, maybeMsg ) =
+                    AC.update
+                        acUpdateConfig
+                        acMsg
+                        model.languageListHowManyToShow
+                        model.languageQueryACState
+                        (filterLanguagesByQuery
+                            model.languageQuery
+                            shared.languages
+                        )
 
-            Publish snipbit ->
+                newModel =
+                    { model | languageQueryACState = newACState }
+            in
+            case maybeMsg of
+                Nothing ->
+                    common.justSetModel newModel
+
+                Just updateMsg ->
+                    update (commonSubPageUtil newModel shared) updateMsg newModel shared
+
+        OnUpdateACWrap toTop ->
+            common.justSetModel
+                { model
+                    | languageQueryACState =
+                        (if toTop then
+                            AC.resetToLastItem
+                         else
+                            AC.resetToFirstItem
+                        )
+                            acUpdateConfig
+                            (filterLanguagesByQuery model.languageQuery shared.languages)
+                            model.languageListHowManyToShow
+                            model.languageQueryACState
+                }
+
+        -- On top of updating the code, we need to check that no highlights are now out of range. If highlights are
+        -- now out of range we minimize them to the greatest size they can be whilst still being in range.
+        OnUpdateCode { newCode, action, deltaRange } ->
+            let
+                currentCode =
+                    model.code
+
+                newHighlightedComments =
+                    Array.map
+                        (\comment ->
+                            case comment.range of
+                                Nothing ->
+                                    comment
+
+                                Just aRange ->
+                                    { comment
+                                        | range =
+                                            Just <|
+                                                Range.getNewRangeAfterDelta
+                                                    currentCode
+                                                    newCode
+                                                    action
+                                                    deltaRange
+                                                    aRange
+                                    }
+                        )
+                        currentHighlightedComments
+            in
+            common.justSetModel
+                { model
+                    | code = newCode
+                    , highlightedComments = newHighlightedComments
+                }
+
+        GoToCodeTab ->
+            ( { model | previewMarkdown = False }
+            , shared
+            , Route.navigateTo Route.CreateSnipbitCodeIntroductionPage
+            )
+
+        Reset ->
+            ( init, shared, Route.navigateTo Route.CreateSnipbitNamePage )
+
+        AddFrame ->
+            let
+                newModel =
+                    { model
+                        | highlightedComments =
+                            Array.push { range = Nothing, comment = Nothing } currentHighlightedComments
+                    }
+
+                newMsg =
+                    GoTo <| Route.CreateSnipbitCodeFramePage <| Array.length newModel.highlightedComments
+            in
+            update (commonSubPageUtil newModel shared) newMsg newModel shared
+
+        RemoveFrame ->
+            let
+                newHighlightedComments =
+                    Array.slice 0 (Array.length currentHighlightedComments - 1) currentHighlightedComments
+
+                newModel =
+                    { model | highlightedComments = newHighlightedComments }
+            in
+            case shared.route of
+                Route.CreateSnipbitCodeIntroductionPage ->
+                    common.justSetModel newModel
+
+                Route.CreateSnipbitCodeConclusionPage ->
+                    common.justSetModel newModel
+
+                -- We need to go "down" a tab if the user was on the last tab and they removed a tab.
+                Route.CreateSnipbitCodeFramePage frameNumber ->
+                    let
+                        frameIndex =
+                            frameNumber - 1
+                    in
+                    if frameIndex >= Array.length newHighlightedComments then
+                        update
+                            (commonSubPageUtil newModel shared)
+                            (GoTo <|
+                                Route.CreateSnipbitCodeFramePage <|
+                                    Array.length newHighlightedComments
+                            )
+                            newModel
+                            shared
+                    else
+                        common.justSetModel newModel
+
+                -- Should never happen.
+                _ ->
+                    common.justSetModel newModel
+
+        TogglePreviewMarkdown ->
+            common.justSetModel <| Util.togglePreviewMarkdown model
+
+        JumpToLineFromPreviousFrame ->
+            case shared.route of
+                Route.CreateSnipbitCodeFramePage frameNumber ->
+                    ( { model
+                        | highlightedComments =
+                            ArrayExtra.update
+                                (frameNumber - 1)
+                                (\hc -> { hc | range = Nothing })
+                                model.highlightedComments
+                      }
+                    , shared
+                    , Route.modifyTo shared.route
+                    )
+
+                _ ->
+                    common.doNothing
+
+        OnUpdateLanguageQuery newLanguageQuery ->
+            common.justSetModel { model | languageQuery = newLanguageQuery }
+
+        SelectLanguage maybeEncodedLang ->
+            let
+                language =
+                    case maybeEncodedLang of
+                        -- Erasing the selected language.
+                        Nothing ->
+                            Nothing
+
+                        -- Selecting a language.
+                        Just encodedLang ->
+                            Util.quote
+                                >> Decode.decodeString JSON.Language.decoder
+                                >> Result.toMaybe
+                            <|
+                                encodedLang
+
+                -- If the user wants to select a new language, we help them by focussing the input box.
+                newCmd =
+                    if Util.isNothing language then
+                        Util.domFocus (always NoOp) "language-query-input"
+                    else
+                        Cmd.none
+
+                newLanguageQuery =
+                    case language of
+                        Nothing ->
+                            ""
+
+                        Just aLanguage ->
+                            Editor.getHumanReadableName aLanguage
+
+                newModel =
+                    { model
+                        | language = language
+                        , languageQuery = newLanguageQuery
+                    }
+            in
+            ( newModel, shared, newCmd )
+
+        OnUpdateName newName ->
+            common.justSetModel { model | name = newName }
+
+        OnUpdateDescription newDescription ->
+            common.justSetModel { model | description = newDescription }
+
+        OnUpdateTagInput newTagInput ->
+            if String.endsWith " " newTagInput then
                 let
-                    publishSnipbitAction =
-                        common.justProduceCmd <| common.api.post.createSnipbit snipbit OnPublishFailure OnPublishSuccess
+                    newTag =
+                        String.dropRight 1 newTagInput
+
+                    newTags =
+                        Util.addUniqueNonEmptyString newTag model.tags
                 in
-                    common.makeSingletonRequest RT.PublishSnipbit publishSnipbitAction
+                common.justSetModel
+                    { model
+                        | tagInput = ""
+                        , tags = newTags
+                    }
+            else
+                common.justSetModel { model | tagInput = newTagInput }
 
-            OnPublishSuccess { targetID } ->
-                ( init
-                , { shared | userTidbits = Nothing }
-                , Route.navigateTo <| Route.ViewSnipbitIntroductionPage Nothing targetID
-                )
-                    |> common.andFinishRequest RT.PublishSnipbit
+        RemoveTag tagName ->
+            common.justSetModel { model | tags = List.filter (\aTag -> aTag /= tagName) model.tags }
 
-            OnPublishFailure apiError ->
-                common.justSetModalError apiError
-                    |> common.andFinishRequest RT.PublishSnipbit
+        AddTag tagName ->
+            common.justSetModel
+                { model
+                    | tags = Util.addUniqueNonEmptyString tagName model.tags
+                    , tagInput = ""
+                }
+
+        OnUpdateFrameComment index newComment ->
+            case Array.get index currentHighlightedComments of
+                Nothing ->
+                    common.doNothing
+
+                Just highlightComment ->
+                    let
+                        newHighlightComment =
+                            { highlightComment | comment = Just newComment }
+
+                        newHighlightedComments =
+                            Array.set index newHighlightComment currentHighlightedComments
+                    in
+                    common.justSetModel { model | highlightedComments = newHighlightedComments }
+
+        OnUpdateIntroduction newIntro ->
+            common.justSetModel { model | introduction = newIntro }
+
+        OnUpdateConclusion newConclusion ->
+            common.justSetModel { model | conclusion = newConclusion }
+
+        Publish snipbit ->
+            let
+                publishSnipbitAction =
+                    common.justProduceCmd <| common.api.post.createSnipbit snipbit OnPublishFailure OnPublishSuccess
+            in
+            common.makeSingletonRequest RT.PublishSnipbit publishSnipbitAction
+
+        OnPublishSuccess { targetID } ->
+            ( init
+            , { shared | userTidbits = Nothing }
+            , Route.navigateTo <| Route.ViewSnipbitIntroductionPage Nothing targetID
+            )
+                |> common.andFinishRequest RT.PublishSnipbit
+
+        OnPublishFailure apiError ->
+            common.justSetModalError apiError
+                |> common.andFinishRequest RT.PublishSnipbit
 
 
 {-| Config for language-list auto-complete (used in snipbit creation).
@@ -450,25 +450,25 @@ acUpdateConfig =
         enterKeyCode =
             13
     in
-        AC.updateConfig
-            { toId = (toString << Tuple.first)
-            , onKeyDown =
-                \keyCode maybeID ->
-                    if keyCode == downKeyCode || keyCode == upKeyCode then
+    AC.updateConfig
+        { toId = toString << Tuple.first
+        , onKeyDown =
+            \keyCode maybeID ->
+                if keyCode == downKeyCode || keyCode == upKeyCode then
+                    Nothing
+                else if keyCode == enterKeyCode then
+                    if Util.isNothing maybeID then
                         Nothing
-                    else if keyCode == enterKeyCode then
-                        if Util.isNothing maybeID then
-                            Nothing
-                        else
-                            Just <| SelectLanguage maybeID
                     else
-                        Nothing
-            , onTooLow = Just <| OnUpdateACWrap False
-            , onTooHigh = Just <| OnUpdateACWrap True
-            , onMouseClick =
-                \id ->
-                    Just <| SelectLanguage <| Just id
-            , onMouseLeave = \_ -> Nothing
-            , onMouseEnter = \_ -> Nothing
-            , separateSelections = False
-            }
+                        Just <| SelectLanguage maybeID
+                else
+                    Nothing
+        , onTooLow = Just <| OnUpdateACWrap False
+        , onTooHigh = Just <| OnUpdateACWrap True
+        , onMouseClick =
+            \id ->
+                Just <| SelectLanguage <| Just id
+        , onMouseLeave = \_ -> Nothing
+        , onMouseEnter = \_ -> Nothing
+        , separateSelections = False
+        }

--- a/frontend/src/Pages/CreateSnipbit/View.elm
+++ b/frontend/src/Pages/CreateSnipbit/View.elm
@@ -5,8 +5,8 @@ import Autocomplete as AC
 import DefaultServices.Util as Util
 import Elements.Simple.Editor as Editor
 import Elements.Simple.Tags as Tags
-import Html exposing (Html, div, text, button, hr, textarea, input)
-import Html.Attributes exposing (class, classList, disabled, hidden, value, id, placeholder)
+import Html exposing (Html, button, div, hr, input, text, textarea)
+import Html.Attributes exposing (class, classList, disabled, hidden, id, placeholder, value)
 import Html.Events exposing (onClick, onInput)
 import Keyboard.Extra as KK
 import Models.RequestTracker as RT
@@ -56,11 +56,11 @@ view model shared =
                     , children = [ Html.text (Tuple.second languagePair) ]
                     }
             in
-                AC.viewConfig
-                    { toId = (toString << Tuple.first)
-                    , ul = [ class "lang-select-ac" ]
-                    , li = customizedLi
-                    }
+            AC.viewConfig
+                { toId = toString << Tuple.first
+                , ul = [ class "lang-select-ac" ]
+                , li = customizedLi
+                }
 
         createSnipbitNavbar : Html Msg
         createSnipbitNavbar =
@@ -255,17 +255,17 @@ view model shared =
                                                     newKeysDown =
                                                         kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
                                                 in
-                                                    if key == KK.Tab then
-                                                        if newKeysDown == shared.keysDown then
-                                                            Just NoOp
-                                                        else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                            Just <| GoTo <| Route.CreateSnipbitCodeFramePage 1
-                                                        else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                            Just <| GoTo <| Route.CreateSnipbitTagsPage
-                                                        else
-                                                            Nothing
+                                                if key == KK.Tab then
+                                                    if newKeysDown == shared.keysDown then
+                                                        Just NoOp
+                                                    else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                        Just <| GoTo <| Route.CreateSnipbitCodeFramePage 1
+                                                    else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                        Just <| GoTo <| Route.CreateSnipbitTagsPage
                                                     else
                                                         Nothing
+                                                else
+                                                    Nothing
                                             )
                                         ]
                                         []
@@ -277,49 +277,49 @@ view model shared =
                                         frameNumber - 1
 
                                     frameText =
-                                        (Array.get frameIndex model.highlightedComments)
+                                        Array.get frameIndex model.highlightedComments
                                             |> Maybe.andThen .comment
                                             |> Maybe.withDefault ""
                                 in
-                                    Util.markdownOr
-                                        markdownOpen
-                                        frameText
-                                        (textarea
-                                            [ placeholder <|
-                                                "Frame "
-                                                    ++ (toString frameNumber)
-                                                    ++ "\n\n"
-                                                    ++ "Highlight a chunk of code and explain it..."
-                                            , id "frame-input"
-                                            , onInput <| OnUpdateFrameComment frameIndex
-                                            , value frameText
-                                            , Util.onKeydownPreventDefault
-                                                (\key ->
-                                                    let
-                                                        newKeysDown =
-                                                            kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
-                                                    in
-                                                        if key == KK.Tab then
-                                                            if newKeysDown == shared.keysDown then
-                                                                Just NoOp
-                                                            else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                                Just <|
-                                                                    GoTo <|
-                                                                        Route.CreateSnipbitCodeFramePage
-                                                                            (frameNumber + 1)
-                                                            else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                                Just <|
-                                                                    GoTo <|
-                                                                        Route.CreateSnipbitCodeFramePage
-                                                                            (frameNumber - 1)
-                                                            else
-                                                                Nothing
-                                                        else
-                                                            Nothing
-                                                )
-                                            ]
-                                            []
-                                        )
+                                Util.markdownOr
+                                    markdownOpen
+                                    frameText
+                                    (textarea
+                                        [ placeholder <|
+                                            "Frame "
+                                                ++ toString frameNumber
+                                                ++ "\n\n"
+                                                ++ "Highlight a chunk of code and explain it..."
+                                        , id "frame-input"
+                                        , onInput <| OnUpdateFrameComment frameIndex
+                                        , value frameText
+                                        , Util.onKeydownPreventDefault
+                                            (\key ->
+                                                let
+                                                    newKeysDown =
+                                                        kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
+                                                in
+                                                if key == KK.Tab then
+                                                    if newKeysDown == shared.keysDown then
+                                                        Just NoOp
+                                                    else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                        Just <|
+                                                            GoTo <|
+                                                                Route.CreateSnipbitCodeFramePage
+                                                                    (frameNumber + 1)
+                                                    else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                        Just <|
+                                                            GoTo <|
+                                                                Route.CreateSnipbitCodeFramePage
+                                                                    (frameNumber - 1)
+                                                    else
+                                                        Nothing
+                                                else
+                                                    Nothing
+                                            )
+                                        ]
+                                        []
+                                    )
 
                             Route.CreateSnipbitCodeConclusionPage ->
                                 Util.markdownOr
@@ -336,20 +336,20 @@ view model shared =
                                                     newKeysDown =
                                                         kkUpdateWrapper (KK.Down <| KK.toCode key) shared.keysDown
                                                 in
-                                                    if key == KK.Tab then
-                                                        if newKeysDown == shared.keysDown then
-                                                            Just NoOp
-                                                        else if KK.isOneKeyPressed KK.Tab newKeysDown then
-                                                            Just NoOp
-                                                        else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
-                                                            Just <|
-                                                                GoTo <|
-                                                                    Route.CreateSnipbitCodeFramePage
-                                                                        (Array.length model.highlightedComments)
-                                                        else
-                                                            Nothing
+                                                if key == KK.Tab then
+                                                    if newKeysDown == shared.keysDown then
+                                                        Just NoOp
+                                                    else if KK.isOneKeyPressed KK.Tab newKeysDown then
+                                                        Just NoOp
+                                                    else if KK.isTwoKeysPressed KK.Tab KK.Shift newKeysDown then
+                                                        Just <|
+                                                            GoTo <|
+                                                                Route.CreateSnipbitCodeFramePage
+                                                                    (Array.length model.highlightedComments)
                                                     else
                                                         Nothing
+                                                else
+                                                    Nothing
                                             )
                                         ]
                                         []
@@ -380,50 +380,50 @@ view model shared =
                                         model.highlightedComments
                                 )
                     in
-                        div
-                            [ class "comment-body-bottom-buttons"
-                            , hidden <| markdownOpen
-                            ]
-                            [ button
-                                [ onClick <| GoTo Route.CreateSnipbitCodeIntroductionPage
-                                , classList
-                                    [ ( "selected-frame", shared.route == Route.CreateSnipbitCodeIntroductionPage )
-                                    , ( "introduction-button", True )
-                                    ]
-                                ]
-                                [ text "Introduction" ]
-                            , button
-                                [ onClick <| GoTo Route.CreateSnipbitCodeConclusionPage
-                                , classList
-                                    [ ( "selected-frame", shared.route == Route.CreateSnipbitCodeConclusionPage )
-                                    , ( "conclusion-button", True )
-                                    ]
-                                ]
-                                [ text "Conclusion" ]
-                            , button
-                                [ class "add-or-remove-frame-button"
-                                , onClick <| AddFrame
-                                ]
-                                [ text "+" ]
-                            , button
-                                [ class "add-or-remove-frame-button"
-                                , onClick <| RemoveFrame
-                                , disabled <| Array.length model.highlightedComments <= 1
-                                ]
-                                [ text "-" ]
-                            , hr [] []
-                            , dynamicFrameButtons
-                            ]
-            in
-                div
-                    [ class "create-snipbit-code" ]
-                    [ Editor.view "create-snipbit-code-editor"
-                    , div
-                        [ class "comment-creator" ]
-                        [ body
-                        , tabBar
+                    div
+                        [ class "comment-body-bottom-buttons"
+                        , hidden <| markdownOpen
                         ]
+                        [ button
+                            [ onClick <| GoTo Route.CreateSnipbitCodeIntroductionPage
+                            , classList
+                                [ ( "selected-frame", shared.route == Route.CreateSnipbitCodeIntroductionPage )
+                                , ( "introduction-button", True )
+                                ]
+                            ]
+                            [ text "Introduction" ]
+                        , button
+                            [ onClick <| GoTo Route.CreateSnipbitCodeConclusionPage
+                            , classList
+                                [ ( "selected-frame", shared.route == Route.CreateSnipbitCodeConclusionPage )
+                                , ( "conclusion-button", True )
+                                ]
+                            ]
+                            [ text "Conclusion" ]
+                        , button
+                            [ class "add-or-remove-frame-button"
+                            , onClick <| AddFrame
+                            ]
+                            [ text "+" ]
+                        , button
+                            [ class "add-or-remove-frame-button"
+                            , onClick <| RemoveFrame
+                            , disabled <| Array.length model.highlightedComments <= 1
+                            ]
+                            [ text "-" ]
+                        , hr [] []
+                        , dynamicFrameButtons
+                        ]
+            in
+            div
+                [ class "create-snipbit-code" ]
+                [ Editor.view "create-snipbit-code-editor"
+                , div
+                    [ class "comment-creator" ]
+                    [ body
+                    , tabBar
                     ]
+                ]
 
         viewForTab : Html Msg
         viewForTab =
@@ -473,30 +473,30 @@ view model shared =
                         ]
                         [ text "Publish" ]
     in
-        div
-            [ class "create-snipbit" ]
-            [ div
-                [ class "sub-bar" ]
-                [ button
-                    [ class "create-snipbit-reset-button"
-                    , onClick <| Reset
-                    ]
-                    [ text "Reset" ]
-                , publishButton
-                , case previousFrameRange model shared.route of
-                    Nothing ->
-                        Util.hiddenDiv
+    div
+        [ class "create-snipbit" ]
+        [ div
+            [ class "sub-bar" ]
+            [ button
+                [ class "create-snipbit-reset-button"
+                , onClick <| Reset
+                ]
+                [ text "Reset" ]
+            , publishButton
+            , case previousFrameRange model shared.route of
+                Nothing ->
+                    Util.hiddenDiv
 
-                    Just _ ->
-                        button
-                            [ class "sub-bar-button previous-frame-location"
-                            , onClick JumpToLineFromPreviousFrame
-                            ]
-                            [ text "Previous Frame Location" ]
-                ]
-            , div
-                []
-                [ createSnipbitNavbar
-                , viewForTab
-                ]
+                Just _ ->
+                    button
+                        [ class "sub-bar-button previous-frame-location"
+                        , onClick JumpToLineFromPreviousFrame
+                        ]
+                        [ text "Previous Frame Location" ]
             ]
+        , div
+            []
+            [ createSnipbitNavbar
+            , viewForTab
+            ]
+        ]

--- a/frontend/src/Pages/DefaultModel.elm
+++ b/frontend/src/Pages/DefaultModel.elm
@@ -22,7 +22,8 @@ import Pages.Welcome.Init as WelcomeInit
 {-| The default model (`Pages/Model.elm`) for the application.
 
 NOTE: This default model is outside of `Pages/Init.elm` to avoid circular dependencies, sometimes sub-pages want access
-      to `defaultShared`.
+to `defaultShared`.
+
 -}
 defaultModel : Route.Route -> Flags -> Model.Model
 defaultModel route flags =

--- a/frontend/src/Pages/DevelopStory/JSON.elm
+++ b/frontend/src/Pages/DevelopStory/JSON.elm
@@ -4,7 +4,7 @@ import DefaultServices.Util as Util
 import JSON.Story
 import JSON.Tidbit
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.DevelopStory.Model exposing (..)
 

--- a/frontend/src/Pages/DevelopStory/Model.elm
+++ b/frontend/src/Pages/DevelopStory/Model.elm
@@ -43,4 +43,4 @@ removeTidbit tidbit storyData =
 -}
 remainingTidbits : List Tidbit.Tidbit -> List Tidbit.Tidbit -> List Tidbit.Tidbit
 remainingTidbits currentStories =
-    List.filter (not << (flip List.member) currentStories)
+    List.filter (not << flip List.member currentStories)

--- a/frontend/src/Pages/DevelopStory/Update.elm
+++ b/frontend/src/Pages/DevelopStory/Update.elm
@@ -36,7 +36,7 @@ update (Common common) msg model shared =
                     ( { model
                         | story = Nothing
                         , tidbitsToAdd =
-                            if maybeMapWithDefault (.id >> ((==) storyID)) False model.story then
+                            if maybeMapWithDefault (.id >> (==) storyID) False model.story then
                                 model.tidbitsToAdd
                             else
                                 []
@@ -99,11 +99,11 @@ update (Common common) msg model shared =
                             OnPublishAddedTidbitsFailure
                             OnPublishAddedTidbitsSuccess
             in
-                if List.length tidbits > 0 then
-                    common.makeSingletonRequest RT.PublishNewTidbitsToStory publishAction
-                else
-                    -- Should never happen.
-                    common.doNothing
+            if List.length tidbits > 0 then
+                common.makeSingletonRequest RT.PublishNewTidbitsToStory publishAction
+            else
+                -- Should never happen.
+                common.doNothing
 
         OnPublishAddedTidbitsSuccess expandedStory ->
             ( { model

--- a/frontend/src/Pages/DevelopStory/View.elm
+++ b/frontend/src/Pages/DevelopStory/View.elm
@@ -2,7 +2,7 @@ module Pages.DevelopStory.View exposing (..)
 
 import DefaultServices.Util as Util
 import Elements.Simple.Editor exposing (prettyPrintLanguages)
-import Html exposing (Html, div, button, text, i, span)
+import Html exposing (Html, button, div, i, span, text)
 import Html.Attributes exposing (class, classList, id)
 import Html.Events exposing (onClick)
 import Models.RequestTracker as RT
@@ -78,8 +78,8 @@ view model shared =
                         [ class "flex-box space-around" ]
                         (story.tidbits
                             |> List.indexedMap (\index tidbit -> tidbitBox { state = Finalized index } tidbit)
-                            |> (flip (++)) (List.map (tidbitBox { state = Added }) model.tidbitsToAdd)
-                            |> (flip (++)) Util.emptyFlexBoxesForAlignment
+                            |> flip (++) (List.map (tidbitBox { state = Added }) model.tidbitsToAdd)
+                            |> flip (++) Util.emptyFlexBoxesForAlignment
                         )
                     , div
                         [ class "create-story-page-title" ]
@@ -100,7 +100,7 @@ view model shared =
                             |> Util.sortByDate Tidbit.getLastModified
                             |> List.reverse
                             |> List.map (tidbitBox { state = NotYetAdded })
-                            |> (flip (++)) Util.emptyFlexBoxesForAlignment
+                            |> flip (++) Util.emptyFlexBoxesForAlignment
                         )
                     ]
                 ]

--- a/frontend/src/Pages/Init.elm
+++ b/frontend/src/Pages/Init.elm
@@ -23,4 +23,4 @@ init flags location =
         defaultModelWithRoute =
             defaultModel route flags
     in
-        updateCacheIf LoadModelFromLocalStorage defaultModelWithRoute False
+    updateCacheIf LoadModelFromLocalStorage defaultModelWithRoute False

--- a/frontend/src/Pages/JSON.elm
+++ b/frontend/src/Pages/JSON.elm
@@ -1,14 +1,14 @@
 module Pages.JSON exposing (..)
 
-import Dict
 import DefaultServices.Util exposing (justValueOrNull)
+import Dict
 import Elements.Simple.Editor as Editor
 import JSON.Route
 import JSON.Story
 import JSON.Tidbit
 import JSON.User
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Keyboard.Extra as KK
 import Pages.Browse.JSON as BrowseJSON
@@ -53,7 +53,7 @@ decoder : Model -> Decode.Decoder Model
 decoder model =
     decode Model
         |> required "shared" (sharedDecoder model.shared)
-        |> required "welcomePage" (WelcomeJSON.decoder)
+        |> required "welcomePage" WelcomeJSON.decoder
         |> required "viewSnipbitPage" ViewSnipbitJSON.decoder
         |> required "viewBigbitPage" ViewBigbitJSON.decoder
         |> required "profilePage" ProfileJSON.decoder

--- a/frontend/src/Pages/Model.elm
+++ b/frontend/src/Pages/Model.elm
@@ -4,11 +4,11 @@ import Elements.Simple.Editor as Editor
 import Flags exposing (Flags)
 import Keyboard.Extra as KK
 import Models.ApiError as ApiError
+import Models.RequestTracker as RT
 import Models.Route as Route
 import Models.Story as Story
 import Models.Tidbit as Tidbit
 import Models.User as User
-import Models.RequestTracker as RT
 import Pages.Browse.Model as BrowseModel
 import Pages.Create.Model as CreateModel
 import Pages.CreateBigbit.Model as CreateBigbitModel
@@ -26,6 +26,7 @@ import Pages.Welcome.Model as WelcomeModel
 
 The base page will have nested inside it the state of every individual page as well as `shared`, which will be passed to
 all pages so they can share data.
+
 -}
 type alias Model =
     { shared : Shared
@@ -46,6 +47,7 @@ type alias Model =
 {-| `Shared` model.
 
 All data shared between pages.
+
 -}
 type alias Shared =
     { user : Maybe User.User
@@ -67,6 +69,7 @@ type alias Shared =
 Extra Logic: When someone clicks shift-tab, they could let go of the tab but keep their hand on the shift and click the
 tab again to "double-shift-tab" to allow this behaviour, every shift tab we reset it as if it was the first shift-tab
 clicked.
+
 -}
 kkUpdateWrapper : KK.Msg -> KK.Model -> KK.Model
 kkUpdateWrapper keyMsg keysDown =
@@ -74,18 +77,18 @@ kkUpdateWrapper keyMsg keysDown =
         newKeysDown =
             KK.update keyMsg keysDown
     in
-        case newKeysDown of
-            [ Just key1, Nothing, Just key2 ] ->
-                if
-                    ((KK.fromCode key1) == KK.Tab)
-                        && ((KK.fromCode key2) == KK.Shift)
-                then
-                    [ Just key1, Just key2 ]
-                else
-                    newKeysDown
-
-            _ ->
+    case newKeysDown of
+        [ Just key1, Nothing, Just key2 ] ->
+            if
+                (KK.fromCode key1 == KK.Tab)
+                    && (KK.fromCode key2 == KK.Shift)
+            then
+                [ Just key1, Just key2 ]
+            else
                 newKeysDown
+
+        _ ->
+            newKeysDown
 
 
 {-| Updates `keysDown`.
@@ -96,12 +99,12 @@ updateKeysDown newKeysDown model =
         shared =
             model.shared
     in
-        { model
-            | shared =
-                { shared
-                    | keysDown = newKeysDown
-                }
-        }
+    { model
+        | shared =
+            { shared
+                | keysDown = newKeysDown
+            }
+    }
 
 
 {-| Updates 'keysDown' with the given list of `Key`s.

--- a/frontend/src/Pages/NewStory/JSON.elm
+++ b/frontend/src/Pages/NewStory/JSON.elm
@@ -2,7 +2,7 @@ module Pages.NewStory.JSON exposing (..)
 
 import JSON.Story
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.Story as Story
 import Pages.NewStory.Model exposing (..)

--- a/frontend/src/Pages/NewStory/Model.elm
+++ b/frontend/src/Pages/NewStory/Model.elm
@@ -80,7 +80,7 @@ newTag newTag newStoryData =
                 (\newStory -> { newStory | tags = Util.addUniqueNonEmptyString newTag newStory.tags })
                 newStoryData
     in
-        updateTagInput "" modelWithNewTags
+    updateTagInput "" modelWithNewTags
 
 
 {-| Adds a new tag to the `editingStory` if it's unique and not empty.
@@ -93,7 +93,7 @@ newEditTag newTag newStoryData =
                 (\editingStory -> { editingStory | tags = Util.addUniqueNonEmptyString newTag editingStory.tags })
                 newStoryData
     in
-        updateEditTagInput "" modelWithNewTags
+    updateEditTagInput "" modelWithNewTags
 
 
 {-| Removes a tag from the `newStory` if it exists in the tags.

--- a/frontend/src/Pages/NewStory/Update.elm
+++ b/frontend/src/Pages/NewStory/Update.elm
@@ -47,18 +47,18 @@ update (Common common) msg model shared =
                                     ]
                                 )
             in
-                case route of
-                    Route.CreateStoryNamePage qpEditingStory ->
-                        getEditingStoryAndFocusOn "name-input" qpEditingStory
+            case route of
+                Route.CreateStoryNamePage qpEditingStory ->
+                    getEditingStoryAndFocusOn "name-input" qpEditingStory
 
-                    Route.CreateStoryDescriptionPage qpEditingStory ->
-                        getEditingStoryAndFocusOn "description-input" qpEditingStory
+                Route.CreateStoryDescriptionPage qpEditingStory ->
+                    getEditingStoryAndFocusOn "description-input" qpEditingStory
 
-                    Route.CreateStoryTagsPage qpEditingStory ->
-                        getEditingStoryAndFocusOn "tags-input" qpEditingStory
+                Route.CreateStoryTagsPage qpEditingStory ->
+                    getEditingStoryAndFocusOn "tags-input" qpEditingStory
 
-                    _ ->
-                        common.doNothing
+                _ ->
+                    common.doNothing
 
         OnGetEditingStorySuccess story ->
             case shared.user of
@@ -128,10 +128,10 @@ update (Common common) msg model shared =
                             OnPublishFailure
                             OnPublishSuccess
             in
-                if newStoryDataReadyForPublication model then
-                    common.makeSingletonRequest RT.PublishNewStory publishAction
-                else
-                    common.doNothing
+            if newStoryDataReadyForPublication model then
+                common.makeSingletonRequest RT.PublishNewStory publishAction
+            else
+                common.doNothing
 
         OnPublishSuccess { targetID } ->
             ( init
@@ -169,10 +169,10 @@ update (Common common) msg model shared =
                             OnSaveEditsFailure
                             OnSaveEditsSuccess
             in
-                if editingStoryDataReadyForSave model then
-                    common.makeSingletonRequest RT.UpdateStoryInfo saveEditsAction
-                else
-                    common.doNothing
+            if editingStoryDataReadyForSave model then
+                common.makeSingletonRequest RT.UpdateStoryInfo saveEditsAction
+            else
+                common.doNothing
 
         OnSaveEditsSuccess { targetID } ->
             ( model

--- a/frontend/src/Pages/NewStory/View.elm
+++ b/frontend/src/Pages/NewStory/View.elm
@@ -2,8 +2,8 @@ module Pages.NewStory.View exposing (..)
 
 import DefaultServices.Util as Util
 import Elements.Simple.Tags as Tags
-import Html exposing (Html, div, text, input, textarea, button)
-import Html.Attributes exposing (class, classList, placeholder, value, id, hidden)
+import Html exposing (Html, button, div, input, text, textarea)
+import Html.Attributes exposing (class, classList, hidden, id, placeholder, value)
 import Html.Events exposing (onClick, onInput)
 import Keyboard.Extra as KK
 import Models.RequestTracker as RT
@@ -28,246 +28,246 @@ view model shared =
             Util.isNotNothing editingStoryQueryParam
 
         editingStoryLoaded =
-            (Just model.editingStory.id == editingStoryQueryParam)
+            Just model.editingStory.id == editingStoryQueryParam
     in
-        div
-            [ class "new-story-page"
-            , hidden <| isEditingStory && not editingStoryLoaded
-            ]
+    div
+        [ class "new-story-page"
+        , hidden <| isEditingStory && not editingStoryLoaded
+        ]
+        [ div
+            [ class "sub-bar" ]
+            (case editingStoryQueryParam of
+                Nothing ->
+                    [ button
+                        [ class "sub-bar-button"
+                        , onClick Reset
+                        ]
+                        [ text "Reset" ]
+                    , button
+                        [ classList
+                            [ ( "continue-button", True )
+                            , ( "publish-button", newStoryDataReadyForPublication model )
+                            , ( "disabled-publish-button", not <| newStoryDataReadyForPublication model )
+                            , ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.PublishNewStory )
+                            ]
+                        , onClick Publish
+                        ]
+                        [ text "Proceed to Tidbit Selection" ]
+                    ]
+
+                Just storyID ->
+                    [ button
+                        [ class "sub-bar-button"
+                        , onClick <| CancelEdits storyID
+                        ]
+                        [ text "Cancel" ]
+                    , button
+                        [ classList
+                            [ ( "sub-bar-button save-changes", True )
+                            , ( "publish-button", editingStoryDataReadyForSave model )
+                            , ( "disabled-publish-button", not <| editingStoryDataReadyForSave model )
+                            , ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.UpdateStoryInfo )
+                            ]
+                        , onClick <| SaveEdits storyID
+                        ]
+                        [ text "Save Changes" ]
+                    ]
+            )
+        , div
+            [ class "create-tidbit-navbar" ]
             [ div
-                [ class "sub-bar" ]
-                (case editingStoryQueryParam of
-                    Nothing ->
-                        [ button
-                            [ class "sub-bar-button"
-                            , onClick Reset
-                            ]
-                            [ text "Reset" ]
-                        , button
-                            [ classList
-                                [ ( "continue-button", True )
-                                , ( "publish-button", newStoryDataReadyForPublication model )
-                                , ( "disabled-publish-button", not <| newStoryDataReadyForPublication model )
-                                , ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.PublishNewStory )
-                                ]
-                            , onClick Publish
-                            ]
-                            [ text "Proceed to Tidbit Selection" ]
-                        ]
-
-                    Just storyID ->
-                        [ button
-                            [ class "sub-bar-button"
-                            , onClick <| CancelEdits storyID
-                            ]
-                            [ text "Cancel" ]
-                        , button
-                            [ classList
-                                [ ( "sub-bar-button save-changes", True )
-                                , ( "publish-button", editingStoryDataReadyForSave model )
-                                , ( "disabled-publish-button", not <| editingStoryDataReadyForSave model )
-                                , ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.UpdateStoryInfo )
-                                ]
-                            , onClick <| SaveEdits storyID
-                            ]
-                            [ text "Save Changes" ]
-                        ]
-                )
-            , div
-                [ class "create-tidbit-navbar" ]
-                [ div
-                    [ classList
-                        [ ( "create-tidbit-tab", True )
-                        , ( "create-tidbit-selected-tab"
-                          , case currentRoute of
-                                Route.CreateStoryNamePage _ ->
-                                    True
-
-                                _ ->
-                                    False
-                          )
-                        , ( "filled-in"
-                          , if isEditingStory then
-                                editingNameTabFilledIn model
-                            else
-                                nameTabFilledIn model
-                          )
-                        ]
-                    , onClick <| GoTo <| Route.CreateStoryNamePage editingStoryQueryParam
-                    ]
-                    [ text "Name" ]
-                , div
-                    [ classList
-                        [ ( "create-tidbit-tab", True )
-                        , ( "create-tidbit-selected-tab"
-                          , case currentRoute of
-                                Route.CreateStoryDescriptionPage _ ->
-                                    True
-
-                                _ ->
-                                    False
-                          )
-                        , ( "filled-in"
-                          , if isEditingStory then
-                                editingDescriptionTabFilledIn model
-                            else
-                                descriptionTabFilledIn model
-                          )
-                        ]
-                    , onClick <| GoTo <| Route.CreateStoryDescriptionPage editingStoryQueryParam
-                    ]
-                    [ text "Description" ]
-                , div
-                    [ classList
-                        [ ( "create-tidbit-tab", True )
-                        , ( "create-tidbit-selected-tab"
-                          , case currentRoute of
-                                Route.CreateStoryTagsPage _ ->
-                                    True
-
-                                _ ->
-                                    False
-                          )
-                        , ( "filled-in"
-                          , if isEditingStory then
-                                editingTagsTabFilledIn model
-                            else
-                                tagsTabFilledIn model
-                          )
-                        ]
-                    , onClick <| GoTo <| Route.CreateStoryTagsPage editingStoryQueryParam
-                    ]
-                    [ text "Tags" ]
-                ]
-            , case currentRoute of
-                Route.CreateStoryNamePage qpEditingStory ->
-                    div
-                        [ class "create-new-story-name" ]
-                        (case qpEditingStory of
-                            Nothing ->
-                                [ input
-                                    [ placeholder "Name"
-                                    , id "name-input"
-                                    , onInput OnUpdateName
-                                    , value model.newStory.name
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Tab then
-                                                Just NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Util.limitCharsText 50 model.newStory.name
-                                ]
+                [ classList
+                    [ ( "create-tidbit-tab", True )
+                    , ( "create-tidbit-selected-tab"
+                      , case currentRoute of
+                            Route.CreateStoryNamePage _ ->
+                                True
 
                             _ ->
-                                [ input
-                                    [ placeholder "Edit Story Name"
-                                    , id "name-input"
-                                    , onInput OnEditingUpdateName
-                                    , value model.editingStory.name
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Tab then
-                                                Just NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Util.limitCharsText 50 model.editingStory.name
-                                ]
-                        )
+                                False
+                      )
+                    , ( "filled-in"
+                      , if isEditingStory then
+                            editingNameTabFilledIn model
+                        else
+                            nameTabFilledIn model
+                      )
+                    ]
+                , onClick <| GoTo <| Route.CreateStoryNamePage editingStoryQueryParam
+                ]
+                [ text "Name" ]
+            , div
+                [ classList
+                    [ ( "create-tidbit-tab", True )
+                    , ( "create-tidbit-selected-tab"
+                      , case currentRoute of
+                            Route.CreateStoryDescriptionPage _ ->
+                                True
 
-                Route.CreateStoryDescriptionPage qpEditingStory ->
-                    div
-                        [ class "create-new-story-description" ]
-                        (case qpEditingStory of
-                            Nothing ->
-                                [ textarea
-                                    [ placeholder "Description"
-                                    , id "description-input"
-                                    , onInput OnUpdateDescription
-                                    , value model.newStory.description
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Tab then
-                                                Just NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Util.limitCharsText 300 model.newStory.description
-                                ]
+                            _ ->
+                                False
+                      )
+                    , ( "filled-in"
+                      , if isEditingStory then
+                            editingDescriptionTabFilledIn model
+                        else
+                            descriptionTabFilledIn model
+                      )
+                    ]
+                , onClick <| GoTo <| Route.CreateStoryDescriptionPage editingStoryQueryParam
+                ]
+                [ text "Description" ]
+            , div
+                [ classList
+                    [ ( "create-tidbit-tab", True )
+                    , ( "create-tidbit-selected-tab"
+                      , case currentRoute of
+                            Route.CreateStoryTagsPage _ ->
+                                True
 
-                            Just editingStory ->
-                                [ textarea
-                                    [ placeholder "Edit Story Description"
-                                    , id "description-input"
-                                    , onInput OnEditingUpdateDescription
-                                    , value model.editingStory.description
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Tab then
-                                                Just NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Util.limitCharsText 300 model.editingStory.description
-                                ]
-                        )
-
-                Route.CreateStoryTagsPage qpEditingStory ->
-                    div
-                        [ class "create-new-story-tags" ]
-                        (case qpEditingStory of
-                            Nothing ->
-                                [ input
-                                    [ placeholder "Tags"
-                                    , id "tags-input"
-                                    , onInput OnUpdateTagInput
-                                    , value model.tagInput
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Enter then
-                                                Just <| AddTag model.tagInput
-                                            else if key == KK.Tab then
-                                                Just <| NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Tags.view RemoveTag model.newStory.tags
-                                ]
-
-                            Just _ ->
-                                [ input
-                                    [ placeholder "Edit Story Tags"
-                                    , id "tags-input"
-                                    , onInput OnEditingUpdateTagInput
-                                    , value model.editingStoryTagInput
-                                    , Util.onKeydownPreventDefault
-                                        (\key ->
-                                            if key == KK.Enter then
-                                                Just <|
-                                                    EditingAddTag model.editingStoryTagInput
-                                            else if key == KK.Tab then
-                                                Just <| NoOp
-                                            else
-                                                Nothing
-                                        )
-                                    ]
-                                    []
-                                , Tags.view EditingRemoveTag model.editingStory.tags
-                                ]
-                        )
-
-                _ ->
-                    Util.hiddenDiv
+                            _ ->
+                                False
+                      )
+                    , ( "filled-in"
+                      , if isEditingStory then
+                            editingTagsTabFilledIn model
+                        else
+                            tagsTabFilledIn model
+                      )
+                    ]
+                , onClick <| GoTo <| Route.CreateStoryTagsPage editingStoryQueryParam
+                ]
+                [ text "Tags" ]
             ]
+        , case currentRoute of
+            Route.CreateStoryNamePage qpEditingStory ->
+                div
+                    [ class "create-new-story-name" ]
+                    (case qpEditingStory of
+                        Nothing ->
+                            [ input
+                                [ placeholder "Name"
+                                , id "name-input"
+                                , onInput OnUpdateName
+                                , value model.newStory.name
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Tab then
+                                            Just NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Util.limitCharsText 50 model.newStory.name
+                            ]
+
+                        _ ->
+                            [ input
+                                [ placeholder "Edit Story Name"
+                                , id "name-input"
+                                , onInput OnEditingUpdateName
+                                , value model.editingStory.name
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Tab then
+                                            Just NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Util.limitCharsText 50 model.editingStory.name
+                            ]
+                    )
+
+            Route.CreateStoryDescriptionPage qpEditingStory ->
+                div
+                    [ class "create-new-story-description" ]
+                    (case qpEditingStory of
+                        Nothing ->
+                            [ textarea
+                                [ placeholder "Description"
+                                , id "description-input"
+                                , onInput OnUpdateDescription
+                                , value model.newStory.description
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Tab then
+                                            Just NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Util.limitCharsText 300 model.newStory.description
+                            ]
+
+                        Just editingStory ->
+                            [ textarea
+                                [ placeholder "Edit Story Description"
+                                , id "description-input"
+                                , onInput OnEditingUpdateDescription
+                                , value model.editingStory.description
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Tab then
+                                            Just NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Util.limitCharsText 300 model.editingStory.description
+                            ]
+                    )
+
+            Route.CreateStoryTagsPage qpEditingStory ->
+                div
+                    [ class "create-new-story-tags" ]
+                    (case qpEditingStory of
+                        Nothing ->
+                            [ input
+                                [ placeholder "Tags"
+                                , id "tags-input"
+                                , onInput OnUpdateTagInput
+                                , value model.tagInput
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Enter then
+                                            Just <| AddTag model.tagInput
+                                        else if key == KK.Tab then
+                                            Just <| NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Tags.view RemoveTag model.newStory.tags
+                            ]
+
+                        Just _ ->
+                            [ input
+                                [ placeholder "Edit Story Tags"
+                                , id "tags-input"
+                                , onInput OnEditingUpdateTagInput
+                                , value model.editingStoryTagInput
+                                , Util.onKeydownPreventDefault
+                                    (\key ->
+                                        if key == KK.Enter then
+                                            Just <|
+                                                EditingAddTag model.editingStoryTagInput
+                                        else if key == KK.Tab then
+                                            Just <| NoOp
+                                        else
+                                            Nothing
+                                    )
+                                ]
+                                []
+                            , Tags.view EditingRemoveTag model.editingStory.tags
+                            ]
+                    )
+
+            _ ->
+                Util.hiddenDiv
+        ]

--- a/frontend/src/Pages/Profile/JSON.elm
+++ b/frontend/src/Pages/Profile/JSON.elm
@@ -3,7 +3,7 @@ module Pages.Profile.JSON exposing (..)
 import DefaultServices.Editable as Editable
 import DefaultServices.Util as Util
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.Profile.Model exposing (..)
 

--- a/frontend/src/Pages/Profile/Model.elm
+++ b/frontend/src/Pages/Profile/Model.elm
@@ -39,7 +39,7 @@ isEditingName =
 -}
 cancelEditingName : Model -> Model
 cancelEditingName model =
-    { model | accountName = Maybe.map (Editable.cancelEditing) model.accountName }
+    { model | accountName = Maybe.map Editable.cancelEditing model.accountName }
 
 
 {-| Sets the accountName to `Nothing`.
@@ -67,7 +67,7 @@ setBio originalBio newBio model =
 -}
 cancelEditingBio : Model -> Model
 cancelEditingBio model =
-    { model | accountBio = Maybe.map (Editable.cancelEditing) model.accountBio }
+    { model | accountBio = Maybe.map Editable.cancelEditing model.accountBio }
 
 
 {-| Sets the accountBio to `Nothing`

--- a/frontend/src/Pages/Profile/Update.elm
+++ b/frontend/src/Pages/Profile/Update.elm
@@ -40,12 +40,12 @@ update (Common common) msg model shared =
                             OnSaveEditedNameFailure
                             OnSaveEditedNameSuccess
             in
-                case maybeValidNewName of
-                    Nothing ->
-                        common.doNothing
+            case maybeValidNewName of
+                Nothing ->
+                    common.doNothing
 
-                    Just validNewName ->
-                        common.makeSingletonRequest RT.UpdateName <| updateNameAction validNewName
+                Just validNewName ->
+                    common.makeSingletonRequest RT.UpdateName <| updateNameAction validNewName
 
         OnSaveEditedNameSuccess updatedUser ->
             ( setAccountNameToNothing model
@@ -81,12 +81,12 @@ update (Common common) msg model shared =
                             OnSaveBioEditedFailure
                             OnSaveEditedBioSuccess
             in
-                case maybeValidNewBio of
-                    Nothing ->
-                        common.doNothing
+            case maybeValidNewBio of
+                Nothing ->
+                    common.doNothing
 
-                    Just validNewBio ->
-                        common.makeSingletonRequest RT.UpdateBio <| updateBioAction validNewBio
+                Just validNewBio ->
+                    common.makeSingletonRequest RT.UpdateBio <| updateBioAction validNewBio
 
         OnSaveEditedBioSuccess updatedUser ->
             ( setAccountBioToNothing model
@@ -104,7 +104,7 @@ update (Common common) msg model shared =
                 logoutAction =
                     common.justProduceCmd <| common.api.get.logOut OnLogOutFailure OnLogOutSuccess
             in
-                common.makeSingletonRequest RT.Logout logoutAction
+            common.makeSingletonRequest RT.Logout logoutAction
 
         OnLogOutSuccess basicResponse ->
             -- WARNING (unusual behaviour): The base update will check for this message and reset the entire model.

--- a/frontend/src/Pages/Profile/View.elm
+++ b/frontend/src/Pages/Profile/View.elm
@@ -2,8 +2,8 @@ module Pages.Profile.View exposing (..)
 
 import DefaultServices.Editable exposing (bufferIs)
 import DefaultServices.Util as Util
-import Html exposing (Html, div, button, text, input, i, textarea)
-import Html.Attributes exposing (class, classList, hidden, placeholder, value, disabled)
+import Html exposing (Html, button, div, i, input, text, textarea)
+import Html.Attributes exposing (class, classList, disabled, hidden, placeholder, value)
 import Html.Events exposing (onClick, onInput)
 import Models.RequestTracker as RT
 import Pages.Model exposing (Shared)

--- a/frontend/src/Pages/Update.elm
+++ b/frontend/src/Pages/Update.elm
@@ -22,7 +22,7 @@ import Pages.DefaultModel exposing (defaultModel)
 import Pages.DevelopStory.Messages as DevelopStoryMessages
 import Pages.DevelopStory.Update as DevelopStoryUpdate
 import Pages.Messages exposing (Msg(..))
-import Pages.Model exposing (Model, updateKeysDown, updateKeysDownWithKeys, kkUpdateWrapper)
+import Pages.Model exposing (Model, kkUpdateWrapper, updateKeysDown, updateKeysDownWithKeys)
 import Pages.NewStory.Messages as NewStoryMessages
 import Pages.NewStory.Update as NewStoryUpdate
 import Pages.Profile.Messages as ProfileMessages
@@ -52,8 +52,9 @@ update msg model =
 {-| Wrapper around `update` allowing to cache the model in local storage.
 
 NOTE: Sometimes we don't want to save to the cache, for example when the website originally loads if we save to cache we
-      end up loading what we saved (the default model) instead of what was in there before. As well, we may in the
-      future allow users to turn off automatic cacheing, so this function easily allows to control that.
+end up loading what we saved (the default model) instead of what was in there before. As well, we may in the
+future allow users to turn off automatic cacheing, so this function easily allows to control that.
+
 -}
 updateCacheIf : Msg -> Model -> Bool -> ( Model, Cmd Msg )
 updateCacheIf msg model shouldCache =
@@ -83,7 +84,7 @@ updateCacheIf msg model shouldCache =
                         newRoute =
                             Route.parseLocation location
                     in
-                        handleLocationChange newRoute model
+                    handleLocationChange newRoute model
 
                 LoadModelFromLocalStorage ->
                     ( model, LocalStorage.loadModel () )
@@ -106,7 +107,7 @@ updateCacheIf msg model shouldCache =
                         newModel =
                             { model | shared = { shared | user = Just user } }
                     in
-                        ( newModel, Route.navigateTo shared.route )
+                    ( newModel, Route.navigateTo shared.route )
 
                 OnGetUserAndThenRefreshFailure newApiError ->
                     ( model, Route.navigateTo shared.route )
@@ -126,7 +127,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map WelcomeMessage newSubMsg )
+                    ( newModel, Cmd.map WelcomeMessage newSubMsg )
 
                 ViewSnipbitMessage subMsg ->
                     let
@@ -143,7 +144,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map ViewSnipbitMessage newSubMsg )
+                    ( newModel, Cmd.map ViewSnipbitMessage newSubMsg )
 
                 ViewBigbitMessage subMsg ->
                     let
@@ -160,7 +161,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map ViewBigbitMessage newSubMsg )
+                    ( newModel, Cmd.map ViewBigbitMessage newSubMsg )
 
                 ViewStoryMessage subMsg ->
                     let
@@ -177,7 +178,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map ViewStoryMessage newSubMsg )
+                    ( newModel, Cmd.map ViewStoryMessage newSubMsg )
 
                 ProfileMessage subMsg ->
                     let
@@ -205,7 +206,7 @@ updateCacheIf msg model shouldCache =
                                     , shared = newShared
                                 }
                     in
-                        ( newModel, Cmd.map ProfileMessage newSubMsg )
+                    ( newModel, Cmd.map ProfileMessage newSubMsg )
 
                 NewStoryMessage subMsg ->
                     let
@@ -222,7 +223,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map NewStoryMessage newSubMsg )
+                    ( newModel, Cmd.map NewStoryMessage newSubMsg )
 
                 CreateMessage subMsg ->
                     let
@@ -239,7 +240,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map CreateMessage newSubMsg )
+                    ( newModel, Cmd.map CreateMessage newSubMsg )
 
                 DevelopStoryMessage subMsg ->
                     let
@@ -256,7 +257,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map DevelopStoryMessage newSubMsg )
+                    ( newModel, Cmd.map DevelopStoryMessage newSubMsg )
 
                 CreateSnipbitMessage subMsg ->
                     let
@@ -273,7 +274,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map CreateSnipbitMessage newSubMsg )
+                    ( newModel, Cmd.map CreateSnipbitMessage newSubMsg )
 
                 CreateBigbitMessage subMsg ->
                     let
@@ -290,7 +291,7 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map CreateBigbitMessage newSubMsg )
+                    ( newModel, Cmd.map CreateBigbitMessage newSubMsg )
 
                 BrowseMessage subMsg ->
                     let
@@ -307,12 +308,12 @@ updateCacheIf msg model shouldCache =
                                 , shared = newShared
                             }
                     in
-                        ( newModel, Cmd.map BrowseMessage newSubMsg )
+                    ( newModel, Cmd.map BrowseMessage newSubMsg )
 
                 CodeEditorUpdate { id, value, deltaRange, action } ->
                     case id of
                         "create-snipbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (CreateSnipbitMessage <|
                                     CreateSnipbitMessages.OnUpdateCode
                                         { newCode = value
@@ -322,10 +323,9 @@ updateCacheIf msg model shouldCache =
                                 )
                                 model
                                 shouldCache
-                            )
 
                         "create-bigbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (CreateBigbitMessage <|
                                     CreateBigbitMessages.OnUpdateCode
                                         { newCode = value
@@ -335,7 +335,6 @@ updateCacheIf msg model shouldCache =
                                 )
                                 model
                                 shouldCache
-                            )
 
                         _ ->
                             doNothing
@@ -343,32 +342,28 @@ updateCacheIf msg model shouldCache =
                 CodeEditorSelectionUpdate { id, range } ->
                     case id of
                         "create-snipbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (CreateSnipbitMessage <| CreateSnipbitMessages.OnRangeSelected range)
                                 model
                                 shouldCache
-                            )
 
                         "create-bigbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (CreateBigbitMessage <| CreateBigbitMessages.OnRangeSelected range)
                                 model
                                 shouldCache
-                            )
 
                         "view-snipbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (ViewSnipbitMessage <| ViewSnipbitMessages.OnRangeSelected range)
                                 model
                                 shouldCache
-                            )
 
                         "view-bigbit-code-editor" ->
-                            (updateCacheIf
+                            updateCacheIf
                                 (ViewBigbitMessage <| ViewBigbitMessages.OnRangeSelected range)
                                 model
                                 shouldCache
-                            )
 
                         _ ->
                             doNothing
@@ -381,16 +376,16 @@ updateCacheIf msg model shouldCache =
                         modelWithNewKeys =
                             updateKeysDown newKeysDown model
                     in
-                        -- Key held, but no new key clicked. Get rid of this if we need hotkeys with key-holds.
-                        if model.shared.keysDown == newKeysDown then
-                            doNothing
-                        else
-                            case msg of
-                                KK.Down keyCode ->
-                                    handleKeyPress modelWithNewKeys
+                    -- Key held, but no new key clicked. Get rid of this if we need hotkeys with key-holds.
+                    if model.shared.keysDown == newKeysDown then
+                        doNothing
+                    else
+                        case msg of
+                            KK.Down keyCode ->
+                                handleKeyPress modelWithNewKeys
 
-                                KK.Up keyCode ->
-                                    handleKeyRelease (KK.fromCode keyCode) modelWithNewKeys
+                            KK.Up keyCode ->
+                                handleKeyRelease (KK.fromCode keyCode) modelWithNewKeys
 
                 CloseErrorModal ->
                     ( { model | shared = { shared | apiModalError = Nothing } }
@@ -402,23 +397,24 @@ updateCacheIf msg model shouldCache =
                     , Cmd.none
                     )
     in
-        case shouldCache of
-            True ->
-                ( newModel
-                , Cmd.batch
-                    [ newCmd
-                    , LocalStorage.saveModel newModel
-                    ]
-                )
+    case shouldCache of
+        True ->
+            ( newModel
+            , Cmd.batch
+                [ newCmd
+                , LocalStorage.saveModel newModel
+                ]
+            )
 
-            False ->
-                ( newModel, newCmd )
+        False ->
+            ( newModel, newCmd )
 
 
 {-| Logic for handling new key-press, all keys currently pressed exist in `shared.keysDown`.
 
 NOTE: This doesn't require that a specific element be focussed, put logic for route hotkeys here, if you want a hotkey
-      only if a certain element is focussed, stick to putting that on the element itself.
+only if a certain element is focussed, stick to putting that on the element itself.
+
 -}
 handleKeyPress : Model -> ( Model, Cmd Msg )
 handleKeyPress model =
@@ -473,104 +469,104 @@ handleKeyPress model =
             else
                 watchForLeftAndRightArrow onLeft onRight
     in
-        case model.shared.route of
-            Route.CreateBigbitNamePage ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo Route.CreateBigbitDescriptionPage)
-                    Cmd.none
+    case model.shared.route of
+        Route.CreateBigbitNamePage ->
+            watchForTabAndShiftTab
+                (Route.navigateTo Route.CreateBigbitDescriptionPage)
+                Cmd.none
 
-            Route.CreateBigbitDescriptionPage ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo Route.CreateBigbitTagsPage)
-                    (Route.navigateTo Route.CreateBigbitNamePage)
+        Route.CreateBigbitDescriptionPage ->
+            watchForTabAndShiftTab
+                (Route.navigateTo Route.CreateBigbitTagsPage)
+                (Route.navigateTo Route.CreateBigbitNamePage)
 
-            Route.CreateBigbitTagsPage ->
-                watchForTabAndShiftTab
-                    (Util.cmdFromMsg <| CreateBigbitMessage CreateBigbitMessages.GoToCodeTab)
-                    (Route.navigateTo Route.CreateBigbitDescriptionPage)
+        Route.CreateBigbitTagsPage ->
+            watchForTabAndShiftTab
+                (Util.cmdFromMsg <| CreateBigbitMessage CreateBigbitMessages.GoToCodeTab)
+                (Route.navigateTo Route.CreateBigbitDescriptionPage)
 
-            Route.CreateSnipbitNamePage ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo Route.CreateSnipbitDescriptionPage)
-                    (Cmd.none)
+        Route.CreateSnipbitNamePage ->
+            watchForTabAndShiftTab
+                (Route.navigateTo Route.CreateSnipbitDescriptionPage)
+                Cmd.none
 
-            Route.CreateSnipbitDescriptionPage ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo Route.CreateSnipbitLanguagePage)
-                    (Route.navigateTo Route.CreateSnipbitNamePage)
+        Route.CreateSnipbitDescriptionPage ->
+            watchForTabAndShiftTab
+                (Route.navigateTo Route.CreateSnipbitLanguagePage)
+                (Route.navigateTo Route.CreateSnipbitNamePage)
 
-            Route.CreateSnipbitLanguagePage ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo Route.CreateSnipbitTagsPage)
-                    (Route.navigateTo Route.CreateSnipbitDescriptionPage)
+        Route.CreateSnipbitLanguagePage ->
+            watchForTabAndShiftTab
+                (Route.navigateTo Route.CreateSnipbitTagsPage)
+                (Route.navigateTo Route.CreateSnipbitDescriptionPage)
 
-            Route.CreateSnipbitTagsPage ->
-                watchForTabAndShiftTab
-                    (Util.cmdFromMsg <| CreateSnipbitMessage CreateSnipbitMessages.GoToCodeTab)
-                    (Route.navigateTo Route.CreateSnipbitLanguagePage)
+        Route.CreateSnipbitTagsPage ->
+            watchForTabAndShiftTab
+                (Util.cmdFromMsg <| CreateSnipbitMessage CreateSnipbitMessages.GoToCodeTab)
+                (Route.navigateTo Route.CreateSnipbitLanguagePage)
 
-            Route.ViewSnipbitIntroductionPage fromStoryID mongoID ->
-                viewSnipbitWatchForLeftAndRightArrow
-                    Cmd.none
-                    (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID 1)
+        Route.ViewSnipbitIntroductionPage fromStoryID mongoID ->
+            viewSnipbitWatchForLeftAndRightArrow
+                Cmd.none
+                (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID 1)
 
-            Route.ViewSnipbitFramePage fromStoryID mongoID frameNumber ->
-                viewSnipbitWatchForLeftAndRightArrow
-                    (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID (frameNumber - 1))
-                    (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID (frameNumber + 1))
+        Route.ViewSnipbitFramePage fromStoryID mongoID frameNumber ->
+            viewSnipbitWatchForLeftAndRightArrow
+                (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID (frameNumber - 1))
+                (Route.navigateTo <| Route.ViewSnipbitFramePage fromStoryID mongoID (frameNumber + 1))
 
-            Route.ViewSnipbitConclusionPage fromStoryID mongoID ->
-                viewSnipbitWatchForLeftAndRightArrow
-                    (Route.navigateTo <|
-                        Route.ViewSnipbitFramePage
-                            fromStoryID
-                            mongoID
-                            (model.viewSnipbitPage.snipbit
-                                |> maybeMapWithDefault (.highlightedComments >> Array.length) 0
-                            )
-                    )
-                    Cmd.none
+        Route.ViewSnipbitConclusionPage fromStoryID mongoID ->
+            viewSnipbitWatchForLeftAndRightArrow
+                (Route.navigateTo <|
+                    Route.ViewSnipbitFramePage
+                        fromStoryID
+                        mongoID
+                        (model.viewSnipbitPage.snipbit
+                            |> maybeMapWithDefault (.highlightedComments >> Array.length) 0
+                        )
+                )
+                Cmd.none
 
-            Route.ViewBigbitIntroductionPage fromStoryID mongoID _ ->
-                viewBigbitWatchForLeftAndRightArrow
-                    Cmd.none
-                    (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID 1 Nothing)
+        Route.ViewBigbitIntroductionPage fromStoryID mongoID _ ->
+            viewBigbitWatchForLeftAndRightArrow
+                Cmd.none
+                (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID 1 Nothing)
 
-            Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
-                viewBigbitWatchForLeftAndRightArrow
-                    (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID (frameNumber - 1) Nothing)
-                    (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID (frameNumber + 1) Nothing)
+        Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
+            viewBigbitWatchForLeftAndRightArrow
+                (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID (frameNumber - 1) Nothing)
+                (Route.navigateTo <| Route.ViewBigbitFramePage fromStoryID mongoID (frameNumber + 1) Nothing)
 
-            Route.ViewBigbitConclusionPage fromStoryID mongoID _ ->
-                viewBigbitWatchForLeftAndRightArrow
-                    (Route.navigateTo <|
-                        Route.ViewBigbitFramePage
-                            fromStoryID
-                            mongoID
-                            (model.viewBigbitPage.bigbit
-                                |> maybeMapWithDefault (.highlightedComments >> Array.length) 0
-                            )
-                            Nothing
-                    )
-                    Cmd.none
+        Route.ViewBigbitConclusionPage fromStoryID mongoID _ ->
+            viewBigbitWatchForLeftAndRightArrow
+                (Route.navigateTo <|
+                    Route.ViewBigbitFramePage
+                        fromStoryID
+                        mongoID
+                        (model.viewBigbitPage.bigbit
+                            |> maybeMapWithDefault (.highlightedComments >> Array.length) 0
+                        )
+                        Nothing
+                )
+                Cmd.none
 
-            Route.CreateStoryNamePage qpEditingStory ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo <| Route.CreateStoryDescriptionPage qpEditingStory)
-                    Cmd.none
+        Route.CreateStoryNamePage qpEditingStory ->
+            watchForTabAndShiftTab
+                (Route.navigateTo <| Route.CreateStoryDescriptionPage qpEditingStory)
+                Cmd.none
 
-            Route.CreateStoryDescriptionPage qpEditingStory ->
-                watchForTabAndShiftTab
-                    (Route.navigateTo <| Route.CreateStoryTagsPage qpEditingStory)
-                    (Route.navigateTo <| Route.CreateStoryNamePage qpEditingStory)
+        Route.CreateStoryDescriptionPage qpEditingStory ->
+            watchForTabAndShiftTab
+                (Route.navigateTo <| Route.CreateStoryTagsPage qpEditingStory)
+                (Route.navigateTo <| Route.CreateStoryNamePage qpEditingStory)
 
-            Route.CreateStoryTagsPage qpEditingStory ->
-                watchForTabAndShiftTab
-                    Cmd.none
-                    (Route.navigateTo <| Route.CreateStoryDescriptionPage qpEditingStory)
+        Route.CreateStoryTagsPage qpEditingStory ->
+            watchForTabAndShiftTab
+                Cmd.none
+                (Route.navigateTo <| Route.CreateStoryDescriptionPage qpEditingStory)
 
-            _ ->
-                doNothing
+        _ ->
+            doNothing
 
 
 {-| Logic for handling new key-release, all keys currently pressed available in `shared.keysDown`.
@@ -587,6 +583,7 @@ users going to routes that don't exist (just goes `back` to the route they were 
 
 Aside from auth logic, nothing else should be put here otherwise it gets crowded. Trigger route hooks on the sub-pages
 and let them hande the logic.
+
 -}
 handleLocationChange : Maybe Route.Route -> Model -> ( Model, Cmd Msg )
 handleLocationChange maybeRoute model =
@@ -617,19 +614,19 @@ handleLocationChange maybeRoute model =
                                         newModel =
                                             modelWithRoute route
                                     in
-                                        ( newModel, LocalStorage.saveModel newModel )
+                                    ( newModel, LocalStorage.saveModel newModel )
 
                                 True ->
                                     let
                                         newModel =
                                             modelWithRoute Route.defaultUnauthRoute
                                     in
-                                        ( newModel
-                                        , Cmd.batch
-                                            [ Route.modifyTo newModel.shared.route
-                                            , LocalStorage.saveModel newModel
-                                            ]
-                                        )
+                                    ( newModel
+                                    , Cmd.batch
+                                        [ Route.modifyTo newModel.shared.route
+                                        , LocalStorage.saveModel newModel
+                                        ]
+                                    )
 
                         True ->
                             case Route.routeRequiresNotAuth route of
@@ -638,19 +635,19 @@ handleLocationChange maybeRoute model =
                                         newModel =
                                             modelWithRoute route
                                     in
-                                        ( newModel, LocalStorage.saveModel newModel )
+                                    ( newModel, LocalStorage.saveModel newModel )
 
                                 True ->
                                     let
                                         newModel =
                                             modelWithRoute Route.defaultAuthRoute
                                     in
-                                        ( newModel
-                                        , Cmd.batch
-                                            [ Route.modifyTo newModel.shared.route
-                                            , LocalStorage.saveModel newModel
-                                            ]
-                                        )
+                                    ( newModel
+                                    , Cmd.batch
+                                        [ Route.modifyTo newModel.shared.route
+                                        , LocalStorage.saveModel newModel
+                                        ]
+                                    )
 
                 triggerRouteHook withMsg =
                     ( newModel
@@ -690,152 +687,152 @@ handleLocationChange maybeRoute model =
                 triggerRouteHookOnBrowsePage =
                     triggerRouteHook <| BrowseMessage <| BrowseMessages.OnRouteHit route
             in
-                -- Handle general route-logic here, routes are a great way to be
-                -- able to trigger certain things (hooks).
-                case route of
-                    Route.LoginPage ->
-                        triggerRouteHookOnWelcomePage
+            -- Handle general route-logic here, routes are a great way to be
+            -- able to trigger certain things (hooks).
+            case route of
+                Route.LoginPage ->
+                    triggerRouteHookOnWelcomePage
 
-                    Route.RegisterPage ->
-                        triggerRouteHookOnWelcomePage
+                Route.RegisterPage ->
+                    triggerRouteHookOnWelcomePage
 
-                    Route.BrowsePage ->
-                        triggerRouteHookOnBrowsePage
+                Route.BrowsePage ->
+                    triggerRouteHookOnBrowsePage
 
-                    Route.CreatePage ->
-                        triggerRouteHookOnCreatePage
+                Route.CreatePage ->
+                    triggerRouteHookOnCreatePage
 
-                    Route.ViewSnipbitIntroductionPage _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitIntroductionPage _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitConclusionPage _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitConclusionPage _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitFramePage _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitFramePage _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitQuestionsPage _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitQuestionsPage _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitQuestionPage _ _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitQuestionPage _ _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitAnswersPage _ _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitAnswersPage _ _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitAnswerPage _ _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitAnswerPage _ _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitQuestionCommentsPage _ _ _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitQuestionCommentsPage _ _ _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitAnswerCommentsPage _ _ _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitAnswerCommentsPage _ _ _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitAskQuestion _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitAskQuestion _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitAnswerQuestion _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitAnswerQuestion _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitEditQuestion _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitEditQuestion _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewSnipbitEditAnswer _ _ _ ->
-                        triggerRouteHookOnViewSnipbitPage
+                Route.ViewSnipbitEditAnswer _ _ _ ->
+                    triggerRouteHookOnViewSnipbitPage
 
-                    Route.ViewBigbitIntroductionPage _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitIntroductionPage _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitFramePage _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitFramePage _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitConclusionPage _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitConclusionPage _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitQuestionsPage _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitQuestionsPage _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitQuestionPage _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitQuestionPage _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitAnswersPage _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitAnswersPage _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitAnswerPage _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitAnswerPage _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitQuestionCommentsPage _ _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitQuestionCommentsPage _ _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitAnswerCommentsPage _ _ _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitAnswerCommentsPage _ _ _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitAskQuestion _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitAskQuestion _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitEditQuestion _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitEditQuestion _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitAnswerQuestion _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitAnswerQuestion _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewBigbitEditAnswer _ _ _ ->
-                        triggerRouteHookOnViewBigbitPage
+                Route.ViewBigbitEditAnswer _ _ _ ->
+                    triggerRouteHookOnViewBigbitPage
 
-                    Route.ViewStoryPage _ ->
-                        triggerRouteHookOnViewStoryPage
+                Route.ViewStoryPage _ ->
+                    triggerRouteHookOnViewStoryPage
 
-                    Route.CreateSnipbitNamePage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitNamePage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitDescriptionPage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitDescriptionPage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitLanguagePage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitLanguagePage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitTagsPage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitTagsPage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitCodeIntroductionPage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitCodeIntroductionPage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitCodeConclusionPage ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitCodeConclusionPage ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateSnipbitCodeFramePage _ ->
-                        triggerRouteHookOnCreateSnipbitPage
+                Route.CreateSnipbitCodeFramePage _ ->
+                    triggerRouteHookOnCreateSnipbitPage
 
-                    Route.CreateBigbitNamePage ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitNamePage ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateBigbitDescriptionPage ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitDescriptionPage ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateBigbitTagsPage ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitTagsPage ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateBigbitCodeIntroductionPage _ ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitCodeIntroductionPage _ ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateBigbitCodeFramePage _ _ ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitCodeFramePage _ _ ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateBigbitCodeConclusionPage _ ->
-                        triggerRouteHookOnCreateBigbitPage
+                Route.CreateBigbitCodeConclusionPage _ ->
+                    triggerRouteHookOnCreateBigbitPage
 
-                    Route.CreateStoryNamePage _ ->
-                        triggerRouteHookOnNewStoryPage
+                Route.CreateStoryNamePage _ ->
+                    triggerRouteHookOnNewStoryPage
 
-                    Route.CreateStoryDescriptionPage _ ->
-                        triggerRouteHookOnNewStoryPage
+                Route.CreateStoryDescriptionPage _ ->
+                    triggerRouteHookOnNewStoryPage
 
-                    Route.CreateStoryTagsPage _ ->
-                        triggerRouteHookOnNewStoryPage
+                Route.CreateStoryTagsPage _ ->
+                    triggerRouteHookOnNewStoryPage
 
-                    Route.DevelopStoryPage _ ->
-                        triggerRouteHookOnDevelopStoryPage
+                Route.DevelopStoryPage _ ->
+                    triggerRouteHookOnDevelopStoryPage
 
-                    _ ->
-                        ( newModel, newCmd )
+                _ ->
+                    ( newModel, newCmd )

--- a/frontend/src/Pages/View.elm
+++ b/frontend/src/Pages/View.elm
@@ -2,7 +2,7 @@ module Pages.View exposing (view)
 
 import DefaultServices.Util as Util
 import Html exposing (Html, div, img, text)
-import Html.Attributes exposing (class, src, classList)
+import Html.Attributes exposing (class, classList, src)
 import Html.Events exposing (onClick)
 import Models.ApiError as ApiError
 import Models.Bigbit as Bigbit
@@ -36,6 +36,7 @@ import Pages.Welcome.View as WelcomeView
 {-| `Base` view.
 
 NOTE: This is the Html entry point to the entire application.
+
 -}
 view : Model -> Html.Html Msg
 view model =
@@ -126,9 +127,10 @@ signUpModal modalMessage =
 {-| Loads the correct view depending on the route we are on.
 
 NOTE: The way we structure the routing we don't need to do ANY checking here to see if the route being loaded is correct
-      (eg. maybe their loading a route that needs auth but they're not logged in) because that logic is already handled
-      in `handleLocationChange`. At the point this function is called, the user has already changed their route, we've
-      already approved that the route change is good and updated the model, and now we just need to render it.
+(eg. maybe their loading a route that needs auth but they're not logged in) because that logic is already handled
+in `handleLocationChange`. At the point this function is called, the user has already changed their route, we've
+already approved that the route change is good and updated the model, and now we just need to render it.
+
 -}
 viewForRoute : Model -> Html.Html Msg
 viewForRoute model =
@@ -166,153 +168,153 @@ viewForRoute model =
         browsePage =
             browseView model.browsePage model.shared
     in
-        case model.shared.route of
-            Route.RegisterPage ->
-                welcomePage
+    case model.shared.route of
+        Route.RegisterPage ->
+            welcomePage
 
-            Route.LoginPage ->
-                welcomePage
+        Route.LoginPage ->
+            welcomePage
 
-            Route.BrowsePage ->
-                browsePage
+        Route.BrowsePage ->
+            browsePage
 
-            Route.ViewSnipbitIntroductionPage _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitIntroductionPage _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitConclusionPage _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitConclusionPage _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitFramePage _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitFramePage _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitQuestionsPage _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitQuestionsPage _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitQuestionPage _ _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitQuestionPage _ _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitAnswersPage _ _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitAnswersPage _ _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitAnswerPage _ _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitAnswerPage _ _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitQuestionCommentsPage _ _ _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitQuestionCommentsPage _ _ _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitAnswerCommentsPage _ _ _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitAnswerCommentsPage _ _ _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitAskQuestion _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitAskQuestion _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitAnswerQuestion _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitAnswerQuestion _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitEditQuestion _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitEditQuestion _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewSnipbitEditAnswer _ _ _ ->
-                viewSnipbitPage
+        Route.ViewSnipbitEditAnswer _ _ _ ->
+            viewSnipbitPage
 
-            Route.ViewBigbitIntroductionPage _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitIntroductionPage _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitFramePage _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitFramePage _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitConclusionPage _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitConclusionPage _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitQuestionsPage _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitQuestionsPage _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitQuestionPage _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitQuestionPage _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitAnswersPage _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitAnswersPage _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitAnswerPage _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitAnswerPage _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitQuestionCommentsPage _ _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitQuestionCommentsPage _ _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitAnswerCommentsPage _ _ _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitAnswerCommentsPage _ _ _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitAskQuestion _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitAskQuestion _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitEditQuestion _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitEditQuestion _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitAnswerQuestion _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitAnswerQuestion _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewBigbitEditAnswer _ _ _ ->
-                viewBigbitPage
+        Route.ViewBigbitEditAnswer _ _ _ ->
+            viewBigbitPage
 
-            Route.ViewStoryPage _ ->
-                viewStoryPage
+        Route.ViewStoryPage _ ->
+            viewStoryPage
 
-            Route.CreatePage ->
-                createPage
+        Route.CreatePage ->
+            createPage
 
-            Route.CreateSnipbitNamePage ->
-                createSnipbitPage
+        Route.CreateSnipbitNamePage ->
+            createSnipbitPage
 
-            Route.CreateSnipbitDescriptionPage ->
-                createSnipbitPage
+        Route.CreateSnipbitDescriptionPage ->
+            createSnipbitPage
 
-            Route.CreateSnipbitLanguagePage ->
-                createSnipbitPage
+        Route.CreateSnipbitLanguagePage ->
+            createSnipbitPage
 
-            Route.CreateSnipbitTagsPage ->
-                createSnipbitPage
+        Route.CreateSnipbitTagsPage ->
+            createSnipbitPage
 
-            Route.CreateSnipbitCodeIntroductionPage ->
-                createSnipbitPage
+        Route.CreateSnipbitCodeIntroductionPage ->
+            createSnipbitPage
 
-            Route.CreateSnipbitCodeFramePage _ ->
-                createSnipbitPage
+        Route.CreateSnipbitCodeFramePage _ ->
+            createSnipbitPage
 
-            Route.CreateSnipbitCodeConclusionPage ->
-                createSnipbitPage
+        Route.CreateSnipbitCodeConclusionPage ->
+            createSnipbitPage
 
-            Route.CreateBigbitNamePage ->
-                createBigbitPage
+        Route.CreateBigbitNamePage ->
+            createBigbitPage
 
-            Route.CreateBigbitDescriptionPage ->
-                createBigbitPage
+        Route.CreateBigbitDescriptionPage ->
+            createBigbitPage
 
-            Route.CreateBigbitTagsPage ->
-                createBigbitPage
+        Route.CreateBigbitTagsPage ->
+            createBigbitPage
 
-            Route.CreateBigbitCodeIntroductionPage _ ->
-                createBigbitPage
+        Route.CreateBigbitCodeIntroductionPage _ ->
+            createBigbitPage
 
-            Route.CreateBigbitCodeFramePage _ _ ->
-                createBigbitPage
+        Route.CreateBigbitCodeFramePage _ _ ->
+            createBigbitPage
 
-            Route.CreateBigbitCodeConclusionPage _ ->
-                createBigbitPage
+        Route.CreateBigbitCodeConclusionPage _ ->
+            createBigbitPage
 
-            Route.CreateStoryNamePage _ ->
-                newStoryPage
+        Route.CreateStoryNamePage _ ->
+            newStoryPage
 
-            Route.CreateStoryDescriptionPage _ ->
-                newStoryPage
+        Route.CreateStoryDescriptionPage _ ->
+            newStoryPage
 
-            Route.CreateStoryTagsPage _ ->
-                newStoryPage
+        Route.CreateStoryTagsPage _ ->
+            newStoryPage
 
-            Route.DevelopStoryPage _ ->
-                developStoryPage
+        Route.DevelopStoryPage _ ->
+            developStoryPage
 
-            Route.ProfilePage ->
-                profilePage
+        Route.ProfilePage ->
+            profilePage
 
 
 {-| `Welcome` view.
@@ -534,7 +536,7 @@ navbar model =
                     True
 
                 _ ->
-                    (List.member
+                    List.member
                         shared.route
                         [ Route.CreatePage
                         , Route.CreateSnipbitNamePage
@@ -547,77 +549,77 @@ navbar model =
                         , Route.CreateBigbitDescriptionPage
                         , Route.CreateBigbitTagsPage
                         ]
-                    )
     in
-        div
+    div
+        [ classList
+            [ ( "nav", True )
+            , ( "nav-wide-2", isWideNav2 model )
+            , ( "nav-wide-3", isWideNav3 model )
+            ]
+        ]
+        [ img
+            [ class "logo"
+            , src "assets/ct-logo-small.png"
+            ]
+            []
+        , div
             [ classList
-                [ ( "nav", True )
-                , ( "nav-wide-2", isWideNav2 model )
-                , ( "nav-wide-3", isWideNav3 model )
+                [ ( "nav-btn left code-tidbit", True )
+                , ( "hidden", Util.isNotNothing shared.user )
                 ]
+            , onClick <| GoTo Route.BrowsePage
             ]
-            [ img
-                [ class "logo"
-                , src "assets/ct-logo-small.png"
+            [ text "Code Tidbit" ]
+        , div
+            [ classList
+                [ ( "nav-btn left", True )
+                , ( "hidden", Util.isNothing shared.user )
+                , ( "selected", browseViewSelected )
                 ]
-                []
-            , div
-                [ classList
-                    [ ( "nav-btn left code-tidbit", True )
-                    , ( "hidden", Util.isNotNothing shared.user )
-                    ]
-                , onClick <| GoTo Route.BrowsePage
-                ]
-                [ text "Code Tidbit" ]
-            , div
-                [ classList
-                    [ ( "nav-btn left", True )
-                    , ( "hidden", Util.isNothing shared.user )
-                    , ( "selected", browseViewSelected )
-                    ]
-                , onClick <| GoTo Route.BrowsePage
-                ]
-                [ text "Browse" ]
-            , div
-                [ classList
-                    [ ( "nav-btn left", True )
-                    , ( "hidden", Util.isNothing shared.user )
-                    , ( "selected", createViewSelected )
-                    ]
-                , onClick <| GoTo Route.CreatePage
-                ]
-                [ text "Create" ]
-            , div
-                [ classList
-                    [ ( "nav-btn right", True )
-                    , ( "hidden", Util.isNothing shared.user )
-                    , ( "selected", profileViewSelected )
-                    ]
-                , onClick <| GoTo Route.ProfilePage
-                ]
-                [ text "Profile" ]
-            , div
-                [ classList
-                    [ ( "nav-btn sign-up right", True )
-                    , ( "hidden", Util.isNotNothing shared.user )
-                    ]
-                , onClick <| GoTo Route.RegisterPage
-                ]
-                [ text "Sign Up" ]
-            , div
-                [ classList
-                    [ ( "nav-btn login right", True )
-                    , ( "hidden", Util.isNotNothing shared.user )
-                    ]
-                , onClick <| GoTo Route.LoginPage
-                ]
-                [ text "Login" ]
+            , onClick <| GoTo Route.BrowsePage
             ]
+            [ text "Browse" ]
+        , div
+            [ classList
+                [ ( "nav-btn left", True )
+                , ( "hidden", Util.isNothing shared.user )
+                , ( "selected", createViewSelected )
+                ]
+            , onClick <| GoTo Route.CreatePage
+            ]
+            [ text "Create" ]
+        , div
+            [ classList
+                [ ( "nav-btn right", True )
+                , ( "hidden", Util.isNothing shared.user )
+                , ( "selected", profileViewSelected )
+                ]
+            , onClick <| GoTo Route.ProfilePage
+            ]
+            [ text "Profile" ]
+        , div
+            [ classList
+                [ ( "nav-btn sign-up right", True )
+                , ( "hidden", Util.isNotNothing shared.user )
+                ]
+            , onClick <| GoTo Route.RegisterPage
+            ]
+            [ text "Sign Up" ]
+        , div
+            [ classList
+                [ ( "nav-btn login right", True )
+                , ( "hidden", Util.isNotNothing shared.user )
+                ]
+            , onClick <| GoTo Route.LoginPage
+            ]
+            [ text "Login" ]
+        ]
 
 
 {-| Returns true if the nav needs to be `$min-width-supported-2` wide.
 
 Currently wide-mode-2 is required for viewing bigbits when the FS is expanded.
+
 -}
 isWideNav2 : Model -> Bool
 isWideNav2 model =
@@ -625,23 +627,24 @@ isWideNav2 model =
         viewBigbitFSOpen =
             ViewBigbitModel.isBigbitFSOpen model.viewBigbitPage.bigbit
     in
-        case model.shared.route of
-            Route.ViewBigbitIntroductionPage _ _ _ ->
-                viewBigbitFSOpen
+    case model.shared.route of
+        Route.ViewBigbitIntroductionPage _ _ _ ->
+            viewBigbitFSOpen
 
-            Route.ViewBigbitFramePage _ _ _ _ ->
-                viewBigbitFSOpen
+        Route.ViewBigbitFramePage _ _ _ _ ->
+            viewBigbitFSOpen
 
-            Route.ViewBigbitConclusionPage _ _ _ ->
-                viewBigbitFSOpen
+        Route.ViewBigbitConclusionPage _ _ _ ->
+            viewBigbitFSOpen
 
-            _ ->
-                False
+        _ ->
+            False
 
 
 {-| Returns true if the nav needs to be `$min-width-supported-3` wide.
 
 Currently wide-mode-3 is required for creating bigbits when the fs is expanded.
+
 -}
 isWideNav3 : Model -> Bool
 isWideNav3 model =
@@ -649,15 +652,15 @@ isWideNav3 model =
         createBigbitFSOpen =
             Bigbit.isFSOpen model.createBigbitPage.fs
     in
-        case model.shared.route of
-            Route.CreateBigbitCodeIntroductionPage _ ->
-                createBigbitFSOpen
+    case model.shared.route of
+        Route.CreateBigbitCodeIntroductionPage _ ->
+            createBigbitFSOpen
 
-            Route.CreateBigbitCodeFramePage _ _ ->
-                createBigbitFSOpen
+        Route.CreateBigbitCodeFramePage _ _ ->
+            createBigbitFSOpen
 
-            Route.CreateBigbitCodeConclusionPage _ ->
-                createBigbitFSOpen
+        Route.CreateBigbitCodeConclusionPage _ ->
+            createBigbitFSOpen
 
-            _ ->
-                False
+        _ ->
+            False

--- a/frontend/src/Pages/ViewBigbit/JSON.elm
+++ b/frontend/src/Pages/ViewBigbit/JSON.elm
@@ -6,7 +6,7 @@ import JSON.Bigbit
 import JSON.QA
 import JSON.TutorialBookmark
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.TutorialBookmark as TB
 import Pages.ViewBigbit.Model exposing (..)

--- a/frontend/src/Pages/ViewBigbit/Messages.elm
+++ b/frontend/src/Pages/ViewBigbit/Messages.elm
@@ -11,11 +11,11 @@ import Models.ApiError exposing (ApiError)
 import Models.Bigbit exposing (Bigbit)
 import Models.Completed exposing (Completed, IsCompleted)
 import Models.Opinion exposing (Opinion, PossibleOpinion)
-import Models.QA exposing (BigbitQA, BigbitCodePointer, BigbitQuestion, Answer, QuestionComment, AnswerComment)
+import Models.QA exposing (Answer, AnswerComment, BigbitCodePointer, BigbitQA, BigbitQuestion, QuestionComment)
 import Models.Range exposing (Range)
-import Models.Vote exposing (Vote)
 import Models.Route exposing (Route)
 import Models.Story exposing (ExpandedStory)
+import Models.Vote exposing (Vote)
 import ProjectTypeAliases exposing (..)
 
 

--- a/frontend/src/Pages/ViewBigbit/Model.elm
+++ b/frontend/src/Pages/ViewBigbit/Model.elm
@@ -4,7 +4,7 @@ import DefaultServices.Util as Util exposing (maybeMapWithDefault)
 import Models.Bigbit exposing (Bigbit, HighlightedComment, isFSOpen)
 import Models.Completed exposing (IsCompleted)
 import Models.Opinion exposing (Opinion, PossibleOpinion)
-import Models.QA exposing (BigbitQA, BigbitQAState, BigbitQuestion, BigbitCodePointer)
+import Models.QA exposing (BigbitCodePointer, BigbitQA, BigbitQAState, BigbitQuestion)
 import Models.Route as Route
 import Models.TutorialBookmark as TB
 import Models.ViewerRelevantHC exposing (ViewerRelevantHC, browsingFrames)
@@ -90,6 +90,7 @@ isBigbitFSOpen =
 {-| Get's the route from the bookmark.
 
 Resumes to the tutorial itself, not the browsing-file state, so the current file is set to `Nothing`.
+
 -}
 routeForBookmark : Maybe String -> String -> TB.TutorialBookmark -> Route.Route
 routeForBookmark maybeStoryID bigbitID bookmark =

--- a/frontend/src/Pages/ViewBigbit/View.elm
+++ b/frontend/src/Pages/ViewBigbit/View.elm
@@ -11,9 +11,9 @@ import Elements.Complex.ViewQuestion as ViewQuestion
 import Elements.Simple.Editor as Editor
 import Elements.Simple.FileStructure as FS
 import Elements.Simple.Markdown as Markdown
-import Elements.Simple.ProgressBar as ProgressBar exposing (TextFormat(Custom), State(..))
+import Elements.Simple.ProgressBar as ProgressBar exposing (State(..), TextFormat(Custom))
 import Elements.Simple.QuestionList as QuestionList
-import Html exposing (Html, div, button, text, i)
+import Html exposing (Html, button, div, i, text)
 import Html.Attributes exposing (class, classList, hidden)
 import Html.Events exposing (onClick)
 import Models.Bigbit as Bigbit
@@ -42,7 +42,7 @@ view model shared =
             isBigbitRHCTabOpen model.relevantHC
 
         goingThroughTutorial =
-            Route.isOnViewBigbitTutorialRoute shared.route && (not rhcTabOpen)
+            Route.isOnViewBigbitTutorialRoute shared.route && not rhcTabOpen
 
         fsOpen =
             fsAllowed && (model.bigbit ||> .fs ||> Bigbit.isFSOpen ?> False)
@@ -61,397 +61,396 @@ view model shared =
                 _ ->
                     False
     in
-        div
-            [ classList
-                [ ( "view-bigbit-page", True )
-                , ( "fs-closed", not <| fsOpen )
-                ]
+    div
+        [ classList
+            [ ( "view-bigbit-page", True )
+            , ( "fs-closed", not <| fsOpen )
             ]
-            [ div
-                [ class "sub-bar" ]
-                [ case ( shared.user, model.possibleOpinion ) of
-                    ( Just user, Just possibleOpinion ) ->
-                        let
-                            ( newMsg, buttonText ) =
-                                case possibleOpinion.rating of
-                                    Nothing ->
-                                        ( AddOpinion
-                                            { contentPointer = possibleOpinion.contentPointer
-                                            , rating = Rating.Like
-                                            }
-                                        , "Love it!"
-                                        )
-
-                                    Just rating ->
-                                        ( RemoveOpinion
-                                            { contentPointer = possibleOpinion.contentPointer
-                                            , rating = rating
-                                            }
-                                        , "Take Back Love"
-                                        )
-                        in
-                            button
-                                [ classList
-                                    [ ( "sub-bar-button heart-button", True )
-                                    , ( "cursor-progress"
-                                      , RT.isMakingRequest shared.apiRequestTracker <|
-                                            RT.AddOrRemoveOpinion TidbitPointer.Bigbit
-                                      )
-                                    ]
-                                , onClick <| newMsg
-                                ]
-                                [ text buttonText ]
-
-                    _ ->
-                        Util.hiddenDiv
-                , case ( shared.viewingStory, model.bigbit ) of
-                    ( Just story, Just bigbit ) ->
-                        case Story.getPreviousTidbitRoute bigbit.id story.id story.tidbits of
-                            Just previousTidbitRoute ->
-                                button
-                                    [ class "sub-bar-button traverse-tidbit-button"
-                                    , onClick <| GoTo previousTidbitRoute
-                                    ]
-                                    [ text "Previous Tidbit" ]
-
-                            _ ->
-                                Util.hiddenDiv
-
-                    _ ->
-                        Util.hiddenDiv
-                , case shared.viewingStory of
-                    Just story ->
-                        button
-                            [ class "sub-bar-button back-to-story-button"
-                            , onClick <| GoTo <| Route.ViewStoryPage story.id
-                            ]
-                            [ text "View Story" ]
-
-                    _ ->
-                        Util.hiddenDiv
-                , case ( shared.viewingStory, model.bigbit ) of
-                    ( Just story, Just bigbit ) ->
-                        case Story.getNextTidbitRoute bigbit.id story.id story.tidbits of
-                            Just nextTidbitRoute ->
-                                button
-                                    [ class "sub-bar-button traverse-tidbit-button"
-                                    , onClick <| GoTo nextTidbitRoute
-                                    ]
-                                    [ text "Next Tidbit" ]
-
-                            _ ->
-                                Util.hiddenDiv
-
-                    _ ->
-                        Util.hiddenDiv
-                , case
-                    ( model.bigbit
-                    , Route.isOnViewBigbitTutorialRoute shared.route
-                    , isBigbitRHCTabOpen model.relevantHC
-                    , model.relevantQuestions
-                    )
-                  of
-                    ( Just bigbit, True, False, Just [] ) ->
-                        button
-                            [ class "sub-bar-button ask-question"
-                            , onClick <|
-                                case shared.user of
-                                    Just _ ->
-                                        GoToAskQuestionWithCodePointer bigbit.id model.tutorialCodePointer
-
-                                    Nothing ->
-                                        SetUserNeedsAuthModal <|
-                                            "We want to answer your question, sign up for free and get access to all of"
-                                                ++ " CodeTidbit in seconds!"
-                            ]
-                            [ text "Ask Question" ]
-
-                    ( Just bigbit, True, False, Just _ ) ->
-                        button
-                            [ class "sub-bar-button view-relevant-questions"
-                            , onClick <| GoToBrowseQuestionsWithCodePointer bigbit.id model.tutorialCodePointer
-                            ]
-                            [ text "Browse Related Questions" ]
-
-                    ( Just bigbit, True, False, Nothing ) ->
-                        button
-                            [ class "sub-bar-button view-all-questions"
-                            , onClick <|
-                                -- We keep the codePointer the same, and if their is no codePointer, we make sure to
-                                -- load the same file if they are looking at a file.
-                                GoToBrowseQuestionsWithCodePointer
-                                    bigbit.id
-                                    (case model.tutorialCodePointer of
-                                        Just _ ->
-                                            model.tutorialCodePointer
-
-                                        Nothing ->
-                                            case
-                                                Route.viewBigbitPageCurrentActiveFile
-                                                    shared.route
-                                                    bigbit
-                                                    model.qa
-                                                    model.qaState
-                                            of
-                                                Just file ->
-                                                    Just { file = file, range = Range.zeroRange }
-
-                                                Nothing ->
-                                                    Nothing
+        ]
+        [ div
+            [ class "sub-bar" ]
+            [ case ( shared.user, model.possibleOpinion ) of
+                ( Just user, Just possibleOpinion ) ->
+                    let
+                        ( newMsg, buttonText ) =
+                            case possibleOpinion.rating of
+                                Nothing ->
+                                    ( AddOpinion
+                                        { contentPointer = possibleOpinion.contentPointer
+                                        , rating = Rating.Like
+                                        }
+                                    , "Love it!"
                                     )
-                            ]
-                            [ text "Browse All Questions" ]
 
-                    _ ->
-                        Util.hiddenDiv
-                , button
-                    [ classList
-                        [ ( "sub-bar-button view-relevant-ranges", True )
-                        , ( "hidden"
-                          , not <|
-                                maybeMapWithDefault
-                                    ViewerRelevantHC.hasFramesButNotBrowsing
-                                    False
-                                    model.relevantHC
-                          )
+                                Just rating ->
+                                    ( RemoveOpinion
+                                        { contentPointer = possibleOpinion.contentPointer
+                                        , rating = rating
+                                        }
+                                    , "Take Back Love"
+                                    )
+                    in
+                    button
+                        [ classList
+                            [ ( "sub-bar-button heart-button", True )
+                            , ( "cursor-progress"
+                              , RT.isMakingRequest shared.apiRequestTracker <|
+                                    RT.AddOrRemoveOpinion TidbitPointer.Bigbit
+                              )
+                            ]
+                        , onClick <| newMsg
                         ]
-                    , onClick BrowseRelevantHC
-                    ]
-                    [ text "Browse Related Frames" ]
-                , case Route.getViewingContentID shared.route of
-                    Just bigbitID ->
-                        button
-                            [ classList
-                                [ ( "sub-bar-button view-relevant-questions", True )
-                                , ( "hidden"
-                                  , not <| (Route.isOnViewBigbitQARoute shared.route) || rhcTabOpen
-                                  )
-                                ]
-                            , onClick <|
-                                GoTo <|
-                                    routeForBookmark
-                                        (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
-                                        bigbitID
-                                        model.bookmark
-                            ]
-                            [ text "Resume Tutorial" ]
+                        [ text buttonText ]
 
-                    Nothing ->
-                        Util.hiddenDiv
+                _ ->
+                    Util.hiddenDiv
+            , case ( shared.viewingStory, model.bigbit ) of
+                ( Just story, Just bigbit ) ->
+                    case Story.getPreviousTidbitRoute bigbit.id story.id story.tidbits of
+                        Just previousTidbitRoute ->
+                            button
+                                [ class "sub-bar-button traverse-tidbit-button"
+                                , onClick <| GoTo previousTidbitRoute
+                                ]
+                                [ text "Previous Tidbit" ]
+
+                        _ ->
+                            Util.hiddenDiv
+
+                _ ->
+                    Util.hiddenDiv
+            , case shared.viewingStory of
+                Just story ->
+                    button
+                        [ class "sub-bar-button back-to-story-button"
+                        , onClick <| GoTo <| Route.ViewStoryPage story.id
+                        ]
+                        [ text "View Story" ]
+
+                _ ->
+                    Util.hiddenDiv
+            , case ( shared.viewingStory, model.bigbit ) of
+                ( Just story, Just bigbit ) ->
+                    case Story.getNextTidbitRoute bigbit.id story.id story.tidbits of
+                        Just nextTidbitRoute ->
+                            button
+                                [ class "sub-bar-button traverse-tidbit-button"
+                                , onClick <| GoTo nextTidbitRoute
+                                ]
+                                [ text "Next Tidbit" ]
+
+                        _ ->
+                            Util.hiddenDiv
+
+                _ ->
+                    Util.hiddenDiv
+            , case
+                ( model.bigbit
+                , Route.isOnViewBigbitTutorialRoute shared.route
+                , isBigbitRHCTabOpen model.relevantHC
+                , model.relevantQuestions
+                )
+              of
+                ( Just bigbit, True, False, Just [] ) ->
+                    button
+                        [ class "sub-bar-button ask-question"
+                        , onClick <|
+                            case shared.user of
+                                Just _ ->
+                                    GoToAskQuestionWithCodePointer bigbit.id model.tutorialCodePointer
+
+                                Nothing ->
+                                    SetUserNeedsAuthModal <|
+                                        "We want to answer your question, sign up for free and get access to all of"
+                                            ++ " CodeTidbit in seconds!"
+                        ]
+                        [ text "Ask Question" ]
+
+                ( Just bigbit, True, False, Just _ ) ->
+                    button
+                        [ class "sub-bar-button view-relevant-questions"
+                        , onClick <| GoToBrowseQuestionsWithCodePointer bigbit.id model.tutorialCodePointer
+                        ]
+                        [ text "Browse Related Questions" ]
+
+                ( Just bigbit, True, False, Nothing ) ->
+                    button
+                        [ class "sub-bar-button view-all-questions"
+                        , onClick <|
+                            -- We keep the codePointer the same, and if their is no codePointer, we make sure to
+                            -- load the same file if they are looking at a file.
+                            GoToBrowseQuestionsWithCodePointer
+                                bigbit.id
+                                (case model.tutorialCodePointer of
+                                    Just _ ->
+                                        model.tutorialCodePointer
+
+                                    Nothing ->
+                                        case
+                                            Route.viewBigbitPageCurrentActiveFile
+                                                shared.route
+                                                bigbit
+                                                model.qa
+                                                model.qaState
+                                        of
+                                            Just file ->
+                                                Just { file = file, range = Range.zeroRange }
+
+                                            Nothing ->
+                                                Nothing
+                                )
+                        ]
+                        [ text "Browse All Questions" ]
+
+                _ ->
+                    Util.hiddenDiv
+            , button
+                [ classList
+                    [ ( "sub-bar-button view-relevant-ranges", True )
+                    , ( "hidden"
+                      , not <|
+                            maybeMapWithDefault
+                                ViewerRelevantHC.hasFramesButNotBrowsing
+                                False
+                                model.relevantHC
+                      )
+                    ]
+                , onClick BrowseRelevantHC
                 ]
-            , case model.bigbit of
+                [ text "Browse Related Frames" ]
+            , case Route.getViewingContentID shared.route of
+                Just bigbitID ->
+                    button
+                        [ classList
+                            [ ( "sub-bar-button view-relevant-questions", True )
+                            , ( "hidden"
+                              , not <| Route.isOnViewBigbitQARoute shared.route || rhcTabOpen
+                              )
+                            ]
+                        , onClick <|
+                            GoTo <|
+                                routeForBookmark
+                                    (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
+                                    bigbitID
+                                    model.bookmark
+                        ]
+                        [ text "Resume Tutorial" ]
+
                 Nothing ->
                     Util.hiddenDiv
+            ]
+        , case model.bigbit of
+            Nothing ->
+                Util.hiddenDiv
 
-                Just bigbit ->
-                    div
-                        [ class "viewer" ]
-                        [ div
-                            [ class "viewer-navbar" ]
-                            [ i
-                                [ classList
-                                    [ ( "material-icons action-button", True )
-                                    , ( "disabled-icon"
-                                      , if not goingThroughTutorial then
-                                            True
-                                        else
-                                            case currentRoute of
-                                                Route.ViewBigbitIntroductionPage _ _ _ ->
-                                                    True
-
-                                                _ ->
-                                                    False
-                                      )
-                                    ]
-                                , onClick <|
-                                    if goingThroughTutorial then
+            Just bigbit ->
+                div
+                    [ class "viewer" ]
+                    [ div
+                        [ class "viewer-navbar" ]
+                        [ i
+                            [ classList
+                                [ ( "material-icons action-button", True )
+                                , ( "disabled-icon"
+                                  , if not goingThroughTutorial then
+                                        True
+                                    else
                                         case currentRoute of
-                                            Route.ViewBigbitConclusionPage fromStoryID mongoID _ ->
-                                                GoTo <|
-                                                    Route.ViewBigbitFramePage
-                                                        fromStoryID
-                                                        mongoID
-                                                        (Array.length bigbit.highlightedComments)
-                                                        Nothing
-
-                                            Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
-                                                GoTo <|
-                                                    Route.ViewBigbitFramePage
-                                                        fromStoryID
-                                                        mongoID
-                                                        (frameNumber - 1)
-                                                        Nothing
-
-                                            _ ->
-                                                NoOp
-                                    else
-                                        NoOp
-                                ]
-                                [ text "arrow_back" ]
-                            , div
-                                [ onClick <|
-                                    if goingThroughTutorial then
-                                        GoTo <|
-                                            Route.ViewBigbitIntroductionPage
-                                                (Route.getFromStoryQueryParamOnViewBigbitRoute currentRoute)
-                                                bigbit.id
-                                                Nothing
-                                    else
-                                        NoOp
-                                , classList
-                                    [ ( "viewer-navbar-item", True )
-                                    , ( "selected"
-                                      , case currentRoute of
                                             Route.ViewBigbitIntroductionPage _ _ _ ->
                                                 True
 
                                             _ ->
                                                 False
-                                      )
-                                    , ( "disabled", not goingThroughTutorial )
-                                    ]
+                                  )
                                 ]
-                                [ text "Introduction" ]
-                            , ProgressBar.view
-                                { state =
-                                    case model.bookmark of
-                                        TB.Introduction ->
-                                            NotStarted
+                            , onClick <|
+                                if goingThroughTutorial then
+                                    case currentRoute of
+                                        Route.ViewBigbitConclusionPage fromStoryID mongoID _ ->
+                                            GoTo <|
+                                                Route.ViewBigbitFramePage
+                                                    fromStoryID
+                                                    mongoID
+                                                    (Array.length bigbit.highlightedComments)
+                                                    Nothing
 
-                                        TB.FrameNumber frameNumber ->
-                                            Started frameNumber
+                                        Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
+                                            GoTo <|
+                                                Route.ViewBigbitFramePage
+                                                    fromStoryID
+                                                    mongoID
+                                                    (frameNumber - 1)
+                                                    Nothing
 
-                                        TB.Conclusion ->
-                                            Completed
-                                , maxPosition = Array.length bigbit.highlightedComments
-                                , disabledStyling = not goingThroughTutorial
-                                , onClickMsg = BackToTutorialSpot
-                                , allowClick =
-                                    goingThroughTutorial
-                                        && (case shared.route of
-                                                Route.ViewBigbitFramePage _ _ _ _ ->
-                                                    True
+                                        _ ->
+                                            NoOp
+                                else
+                                    NoOp
+                            ]
+                            [ text "arrow_back" ]
+                        , div
+                            [ onClick <|
+                                if goingThroughTutorial then
+                                    GoTo <|
+                                        Route.ViewBigbitIntroductionPage
+                                            (Route.getFromStoryQueryParamOnViewBigbitRoute currentRoute)
+                                            bigbit.id
+                                            Nothing
+                                else
+                                    NoOp
+                            , classList
+                                [ ( "viewer-navbar-item", True )
+                                , ( "selected"
+                                  , case currentRoute of
+                                        Route.ViewBigbitIntroductionPage _ _ _ ->
+                                            True
 
-                                                _ ->
-                                                    False
-                                           )
-                                , textFormat =
-                                    Custom
-                                        { notStarted = "0%"
-                                        , started = (\frameNumber -> "Frame " ++ (toString frameNumber))
-                                        , done = "100%"
-                                        }
-                                , shiftLeft = True
-                                , alreadyComplete = { complete = userDoneBigbit, for = ProgressBar.Tidbit }
-                                }
-                            , div
-                                [ onClick <|
-                                    if goingThroughTutorial then
-                                        GoTo <|
-                                            Route.ViewBigbitConclusionPage
-                                                (Route.getFromStoryQueryParamOnViewBigbitRoute currentRoute)
-                                                bigbit.id
-                                                Nothing
+                                        _ ->
+                                            False
+                                  )
+                                , ( "disabled", not goingThroughTutorial )
+                                ]
+                            ]
+                            [ text "Introduction" ]
+                        , ProgressBar.view
+                            { state =
+                                case model.bookmark of
+                                    TB.Introduction ->
+                                        NotStarted
+
+                                    TB.FrameNumber frameNumber ->
+                                        Started frameNumber
+
+                                    TB.Conclusion ->
+                                        Completed
+                            , maxPosition = Array.length bigbit.highlightedComments
+                            , disabledStyling = not goingThroughTutorial
+                            , onClickMsg = BackToTutorialSpot
+                            , allowClick =
+                                goingThroughTutorial
+                                    && (case shared.route of
+                                            Route.ViewBigbitFramePage _ _ _ _ ->
+                                                True
+
+                                            _ ->
+                                                False
+                                       )
+                            , textFormat =
+                                Custom
+                                    { notStarted = "0%"
+                                    , started = \frameNumber -> "Frame " ++ toString frameNumber
+                                    , done = "100%"
+                                    }
+                            , shiftLeft = True
+                            , alreadyComplete = { complete = userDoneBigbit, for = ProgressBar.Tidbit }
+                            }
+                        , div
+                            [ onClick <|
+                                if goingThroughTutorial then
+                                    GoTo <|
+                                        Route.ViewBigbitConclusionPage
+                                            (Route.getFromStoryQueryParamOnViewBigbitRoute currentRoute)
+                                            bigbit.id
+                                            Nothing
+                                else
+                                    NoOp
+                            , classList
+                                [ ( "viewer-navbar-item", True )
+                                , ( "selected"
+                                  , case currentRoute of
+                                        Route.ViewBigbitConclusionPage _ _ _ ->
+                                            True
+
+                                        _ ->
+                                            False
+                                  )
+                                , ( "disabled", not goingThroughTutorial )
+                                ]
+                            ]
+                            [ text "Conclusion" ]
+                        , i
+                            [ classList
+                                [ ( "material-icons action-button", True )
+                                , ( "disabled-icon"
+                                  , if not goingThroughTutorial then
+                                        True
                                     else
-                                        NoOp
-                                , classList
-                                    [ ( "viewer-navbar-item", True )
-                                    , ( "selected"
-                                      , case currentRoute of
+                                        case currentRoute of
                                             Route.ViewBigbitConclusionPage _ _ _ ->
                                                 True
 
                                             _ ->
                                                 False
-                                      )
-                                    , ( "disabled", not goingThroughTutorial )
-                                    ]
+                                  )
                                 ]
-                                [ text "Conclusion" ]
-                            , i
-                                [ classList
-                                    [ ( "material-icons action-button", True )
-                                    , ( "disabled-icon"
-                                      , if not goingThroughTutorial then
-                                            True
-                                        else
-                                            case currentRoute of
-                                                Route.ViewBigbitConclusionPage _ _ _ ->
-                                                    True
+                            , onClick <|
+                                if goingThroughTutorial then
+                                    case currentRoute of
+                                        Route.ViewBigbitIntroductionPage fromStoryID mongoID _ ->
+                                            GoTo <|
+                                                Route.ViewBigbitFramePage fromStoryID mongoID 1 Nothing
 
-                                                _ ->
-                                                    False
-                                      )
-                                    ]
-                                , onClick <|
-                                    if goingThroughTutorial then
-                                        case currentRoute of
-                                            Route.ViewBigbitIntroductionPage fromStoryID mongoID _ ->
-                                                GoTo <|
-                                                    Route.ViewBigbitFramePage fromStoryID mongoID 1 Nothing
+                                        Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
+                                            GoTo <|
+                                                Route.ViewBigbitFramePage
+                                                    fromStoryID
+                                                    mongoID
+                                                    (frameNumber + 1)
+                                                    Nothing
 
-                                            Route.ViewBigbitFramePage fromStoryID mongoID frameNumber _ ->
-                                                GoTo <|
-                                                    Route.ViewBigbitFramePage
-                                                        fromStoryID
-                                                        mongoID
-                                                        (frameNumber + 1)
-                                                        Nothing
-
-                                            _ ->
-                                                NoOp
-                                    else
-                                        NoOp
-                                ]
-                                [ text "arrow_forward" ]
+                                        _ ->
+                                            NoOp
+                                else
+                                    NoOp
                             ]
-                        , div
-                            [ class "view-bigbit-fs" ]
-                            [ FS.view
-                                { isFileSelected =
-                                    (\absolutePath ->
-                                        Route.viewBigbitPageCurrentActiveFile currentRoute bigbit model.qa model.qaState
-                                            |> Maybe.map (FS.isSameFilePath absolutePath)
-                                            |> Maybe.withDefault False
-                                    )
-                                , fileSelectedMsg = SelectFile
-                                , folderSelectedMsg = ToggleFolder
-                                }
-                                bigbit.fs
-                            , i
-                                [ class "close-fs-icon material-icons"
-                                , onClick ToggleFS
-                                ]
-                                [ text "close" ]
-                            , div
-                                [ classList
-                                    [ ( "above-editor-text", True )
-                                    , ( "cursor-not-allowed", not fsAllowed )
-                                    , ( "cursor-default", fsOpen )
-                                    ]
-                                , onClick <|
-                                    if fsOpen || (not fsAllowed) then
-                                        NoOp
-                                    else
-                                        ToggleFS
-                                ]
-                                [ text <|
-                                    case
-                                        Route.viewBigbitPageCurrentActiveFile currentRoute bigbit model.qa model.qaState
-                                    of
-                                        Nothing ->
-                                            "No File Selected"
-
-                                        Just activeFile ->
-                                            activeFile
-                                ]
-                            ]
-                        , Editor.view "view-bigbit-code-editor"
-                        , div
-                            [ class "comment-block" ]
-                            [ viewBigbitCommentBox bigbit model shared ]
+                            [ text "arrow_forward" ]
                         ]
-            ]
+                    , div
+                        [ class "view-bigbit-fs" ]
+                        [ FS.view
+                            { isFileSelected =
+                                \absolutePath ->
+                                    Route.viewBigbitPageCurrentActiveFile currentRoute bigbit model.qa model.qaState
+                                        |> Maybe.map (FS.isSameFilePath absolutePath)
+                                        |> Maybe.withDefault False
+                            , fileSelectedMsg = SelectFile
+                            , folderSelectedMsg = ToggleFolder
+                            }
+                            bigbit.fs
+                        , i
+                            [ class "close-fs-icon material-icons"
+                            , onClick ToggleFS
+                            ]
+                            [ text "close" ]
+                        , div
+                            [ classList
+                                [ ( "above-editor-text", True )
+                                , ( "cursor-not-allowed", not fsAllowed )
+                                , ( "cursor-default", fsOpen )
+                                ]
+                            , onClick <|
+                                if fsOpen || not fsAllowed then
+                                    NoOp
+                                else
+                                    ToggleFS
+                            ]
+                            [ text <|
+                                case
+                                    Route.viewBigbitPageCurrentActiveFile currentRoute bigbit model.qa model.qaState
+                                of
+                                    Nothing ->
+                                        "No File Selected"
+
+                                    Just activeFile ->
+                                        activeFile
+                            ]
+                        ]
+                    , Editor.view "view-bigbit-code-editor"
+                    , div
+                        [ class "comment-block" ]
+                        [ viewBigbitCommentBox bigbit model shared ]
+                    ]
+        ]
 
 
 {-| Gets the comment box for the view bigbit page, can be the markdown for the intro/conclusion/frame, the FS, or the
@@ -468,88 +467,88 @@ viewBigbitCommentBox bigbit model shared =
                 tutorialOpen =
                     not <| rhcTabOpen
             in
-                div
-                    []
-                    [ Markdown.view [ hidden <| not <| tutorialOpen ] <|
-                        case shared.route of
-                            Route.ViewBigbitIntroductionPage _ _ _ ->
-                                bigbit.introduction
+            div
+                []
+                [ Markdown.view [ hidden <| not <| tutorialOpen ] <|
+                    case shared.route of
+                        Route.ViewBigbitIntroductionPage _ _ _ ->
+                            bigbit.introduction
 
-                            Route.ViewBigbitConclusionPage _ _ _ ->
-                                bigbit.conclusion
+                        Route.ViewBigbitConclusionPage _ _ _ ->
+                            bigbit.conclusion
 
-                            Route.ViewBigbitFramePage _ _ frameNumber _ ->
-                                Array.get (frameNumber - 1) bigbit.highlightedComments
-                                    ||> .comment
-                                    ?> ""
+                        Route.ViewBigbitFramePage _ _ frameNumber _ ->
+                            Array.get (frameNumber - 1) bigbit.highlightedComments
+                                ||> .comment
+                                ?> ""
 
-                            _ ->
-                                ""
-                    , div
-                        [ class "view-relevant-hc"
-                        , hidden <| not <| rhcTabOpen
-                        ]
-                        (case model.relevantHC of
-                            Nothing ->
-                                [ Util.hiddenDiv ]
-
-                            Just rhc ->
-                                case rhc.currentHC of
-                                    Nothing ->
-                                        [ Util.hiddenDiv ]
-
-                                    Just index ->
-                                        [ case ViewerRelevantHC.currentFramePair rhc of
-                                            Nothing ->
-                                                Util.hiddenDiv
-
-                                            Just currentFramePair ->
-                                                ViewerRelevantHC.relevantHCTextAboveFrameSpecifyingPosition currentFramePair
-                                        , Markdown.view
-                                            []
-                                            (Array.get index rhc.relevantHC
-                                                |> maybeMapWithDefault (Tuple.second >> .comment) ""
-                                            )
-                                        , div
-                                            [ classList
-                                                [ ( "above-comment-block-button", True )
-                                                , ( "disabled", ViewerRelevantHC.onFirstFrame rhc )
-                                                ]
-                                            , onClick PreviousRelevantHC
-                                            ]
-                                            [ text "Previous" ]
-                                        , div
-                                            [ classList
-                                                [ ( "above-comment-block-button go-to-frame-button", True ) ]
-                                            , onClick
-                                                (Array.get index rhc.relevantHC
-                                                    |> maybeMapWithDefault
-                                                        (GoTo
-                                                            << (\frameNumber ->
-                                                                    Route.ViewBigbitFramePage
-                                                                        (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
-                                                                        bigbit.id
-                                                                        frameNumber
-                                                                        Nothing
-                                                               )
-                                                            << ((+) 1)
-                                                            << Tuple.first
-                                                        )
-                                                        NoOp
-                                                )
-                                            ]
-                                            [ text "Jump To Frame" ]
-                                        , div
-                                            [ classList
-                                                [ ( "above-comment-block-button next-button", True )
-                                                , ( "disabled", ViewerRelevantHC.onLastFrame rhc )
-                                                ]
-                                            , onClick NextRelevantHC
-                                            ]
-                                            [ text "Next" ]
-                                        ]
-                        )
+                        _ ->
+                            ""
+                , div
+                    [ class "view-relevant-hc"
+                    , hidden <| not <| rhcTabOpen
                     ]
+                    (case model.relevantHC of
+                        Nothing ->
+                            [ Util.hiddenDiv ]
+
+                        Just rhc ->
+                            case rhc.currentHC of
+                                Nothing ->
+                                    [ Util.hiddenDiv ]
+
+                                Just index ->
+                                    [ case ViewerRelevantHC.currentFramePair rhc of
+                                        Nothing ->
+                                            Util.hiddenDiv
+
+                                        Just currentFramePair ->
+                                            ViewerRelevantHC.relevantHCTextAboveFrameSpecifyingPosition currentFramePair
+                                    , Markdown.view
+                                        []
+                                        (Array.get index rhc.relevantHC
+                                            |> maybeMapWithDefault (Tuple.second >> .comment) ""
+                                        )
+                                    , div
+                                        [ classList
+                                            [ ( "above-comment-block-button", True )
+                                            , ( "disabled", ViewerRelevantHC.onFirstFrame rhc )
+                                            ]
+                                        , onClick PreviousRelevantHC
+                                        ]
+                                        [ text "Previous" ]
+                                    , div
+                                        [ classList
+                                            [ ( "above-comment-block-button go-to-frame-button", True ) ]
+                                        , onClick
+                                            (Array.get index rhc.relevantHC
+                                                |> maybeMapWithDefault
+                                                    (GoTo
+                                                        << (\frameNumber ->
+                                                                Route.ViewBigbitFramePage
+                                                                    (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
+                                                                    bigbit.id
+                                                                    frameNumber
+                                                                    Nothing
+                                                           )
+                                                        << (+) 1
+                                                        << Tuple.first
+                                                    )
+                                                    NoOp
+                                            )
+                                        ]
+                                        [ text "Jump To Frame" ]
+                                    , div
+                                        [ classList
+                                            [ ( "above-comment-block-button next-button", True )
+                                            , ( "disabled", ViewerRelevantHC.onLastFrame rhc )
+                                            ]
+                                        , onClick NextRelevantHC
+                                        ]
+                                        [ text "Next" ]
+                                    ]
+                    )
+                ]
 
         viewQuestionView qa qaState tab question =
             ViewQuestion.view
@@ -612,16 +611,15 @@ viewBigbitCommentBox bigbit model shared =
                             question.id
                             Nothing
                 , goToAnswerTab =
-                    (\answer ->
+                    \answer ->
                         GoTo <|
                             Route.ViewBigbitAnswerPage
                                 (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
                                 (Route.getTouringQuestionsQueryParamOnViewBigbitQARoute shared.route)
                                 bigbit.id
                                 answer.id
-                    )
                 , goToAnswerCommentsTab =
-                    (\answer ->
+                    \answer ->
                         GoTo <|
                             Route.ViewBigbitAnswerCommentsPage
                                 (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
@@ -629,9 +627,8 @@ viewBigbitCommentBox bigbit model shared =
                                 bigbit.id
                                 answer.id
                                 Nothing
-                    )
                 , goToQuestionComment =
-                    (\questionComment ->
+                    \questionComment ->
                         GoTo <|
                             Route.ViewBigbitQuestionCommentsPage
                                 (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
@@ -639,9 +636,8 @@ viewBigbitCommentBox bigbit model shared =
                                 bigbit.id
                                 question.id
                                 (Just questionComment.id)
-                    )
                 , goToAnswerComment =
-                    (\answerComment ->
+                    \answerComment ->
                         GoTo <|
                             Route.ViewBigbitAnswerCommentsPage
                                 (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
@@ -649,7 +645,6 @@ viewBigbitCommentBox bigbit model shared =
                                 bigbit.id
                                 answerComment.answerID
                                 (Just answerComment.id)
-                    )
                 , goToAnswerQuestion =
                     case shared.user of
                         Just _ ->
@@ -671,25 +666,24 @@ viewBigbitCommentBox bigbit model shared =
                             bigbit.id
                             question.id
                 , goToEditAnswer =
-                    (\answer ->
+                    \answer ->
                         GoTo <|
                             Route.ViewBigbitEditAnswer
                                 (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
                                 bigbit.id
                                 answer.id
-                    )
                 , upvoteQuestion = RateQuestion bigbit.id question.id (Just Vote.Upvote)
                 , removeUpvoteQuestion = RateQuestion bigbit.id question.id Nothing
                 , downvoteQuestion = RateQuestion bigbit.id question.id (Just Vote.Downvote)
                 , removeDownvoteQuestion = RateQuestion bigbit.id question.id Nothing
-                , upvoteAnswer = (\answer -> RateAnswer bigbit.id answer.id (Just Vote.Upvote))
-                , removeUpvoteAnswer = (\answer -> RateAnswer bigbit.id answer.id Nothing)
-                , downvoteAnswer = (\answer -> RateAnswer bigbit.id answer.id (Just Vote.Downvote))
-                , removeDownvoteAnswer = (\answer -> RateAnswer bigbit.id answer.id Nothing)
+                , upvoteAnswer = \answer -> RateAnswer bigbit.id answer.id (Just Vote.Upvote)
+                , removeUpvoteAnswer = \answer -> RateAnswer bigbit.id answer.id Nothing
+                , downvoteAnswer = \answer -> RateAnswer bigbit.id answer.id (Just Vote.Downvote)
+                , removeDownvoteAnswer = \answer -> RateAnswer bigbit.id answer.id Nothing
                 , pinQuestion = PinQuestion bigbit.id question.id True
                 , unpinQuestion = PinQuestion bigbit.id question.id False
-                , pinAnswer = (\answer -> PinAnswer bigbit.id answer.id True)
-                , unpinAnswer = (\answer -> PinAnswer bigbit.id answer.id False)
+                , pinAnswer = \answer -> PinAnswer bigbit.id answer.id True
+                , unpinAnswer = \answer -> PinAnswer bigbit.id answer.id False
                 , deleteAnswer = .id >> DeleteAnswer bigbit.id question.id
                 , commentOnQuestion = SubmitCommentOnQuestion bigbit.id question.id
                 , commentOnAnswer = SubmitCommentOnAnswer bigbit.id question.id
@@ -707,255 +701,254 @@ viewBigbitCommentBox bigbit model shared =
                 , deletingAnswers = QA.getDeletingAnswers bigbit.id qaState
                 }
     in
-        case shared.route of
-            Route.ViewBigbitIntroductionPage _ _ _ ->
-                tutorialRoute
+    case shared.route of
+        Route.ViewBigbitIntroductionPage _ _ _ ->
+            tutorialRoute
 
-            Route.ViewBigbitFramePage _ _ _ _ ->
-                tutorialRoute
+        Route.ViewBigbitFramePage _ _ _ _ ->
+            tutorialRoute
 
-            Route.ViewBigbitConclusionPage _ _ _ ->
-                tutorialRoute
+        Route.ViewBigbitConclusionPage _ _ _ ->
+            tutorialRoute
 
-            Route.ViewBigbitQuestionsPage _ bigbitID ->
-                case model.qa of
-                    Just qa ->
-                        let
-                            browseCodePointer =
-                                model.qaState |> QA.getBrowseCodePointer bigbitID
+        Route.ViewBigbitQuestionsPage _ bigbitID ->
+            case model.qa of
+                Just qa ->
+                    let
+                        browseCodePointer =
+                            model.qaState |> QA.getBrowseCodePointer bigbitID
 
-                            ( isHighlighting, remainingQuestions ) =
+                        ( isHighlighting, remainingQuestions ) =
+                            case browseCodePointer of
+                                Nothing ->
+                                    ( False, qa.questions )
+
+                                Just ({ file, range } as codePointer) ->
+                                    if Range.isEmptyRange range then
+                                        ( False
+                                        , qa.questions
+                                            |> List.filter (.codePointer >> .file >> FS.isSameFilePath file)
+                                        )
+                                    else
+                                        ( True
+                                        , qa.questions
+                                            |> List.filter
+                                                (.codePointer >> QA.isBigbitCodePointerOverlap codePointer)
+                                        )
+                    in
+                    div
+                        [ class "view-questions" ]
+                        [ QuestionList.view
+                            { questionBoxRenderConfig =
+                                { onClickQuestionBox =
+                                    \question ->
+                                        GoTo <|
+                                            Route.ViewBigbitQuestionPage
+                                                (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
+                                                (Route.getTouringQuestionsQueryParamOnViewBigbitQARoute shared.route)
+                                                bigbitID
+                                                question.id
+                                }
+                            , isHighlighting = isHighlighting
+                            , allQuestionText =
+                                case browseCodePointer of
+                                    Just _ ->
+                                        "Questions in File"
+
+                                    Nothing ->
+                                        "All Questions"
+                            , noQuestionsDuringSearchText = "None found"
+                            , noQuestionsNotDuringSearchText =
                                 case browseCodePointer of
                                     Nothing ->
-                                        ( False, qa.questions )
+                                        "Be the first to ask a question"
 
-                                    Just ({ file, range } as codePointer) ->
-                                        if Range.isEmptyRange range then
-                                            ( False
-                                            , qa.questions
-                                                |> List.filter (.codePointer >> .file >> FS.isSameFilePath file)
-                                            )
-                                        else
-                                            ( True
-                                            , qa.questions
-                                                |> List.filter
-                                                    (.codePointer >> QA.isBigbitCodePointerOverlap codePointer)
-                                            )
-                        in
-                            div
-                                [ class "view-questions" ]
-                                [ QuestionList.view
-                                    { questionBoxRenderConfig =
-                                        { onClickQuestionBox =
-                                            (\question ->
-                                                GoTo <|
-                                                    Route.ViewBigbitQuestionPage
-                                                        (Route.getFromStoryQueryParamOnViewBigbitRoute shared.route)
-                                                        (Route.getTouringQuestionsQueryParamOnViewBigbitQARoute shared.route)
-                                                        bigbitID
-                                                        question.id
-                                            )
-                                        }
-                                    , isHighlighting = isHighlighting
-                                    , allQuestionText =
-                                        case browseCodePointer of
-                                            Just _ ->
-                                                "Questions in File"
+                                    Just _ ->
+                                        "None found"
+                            , askQuestion =
+                                case shared.user of
+                                    Nothing ->
+                                        SetUserNeedsAuthModal <|
+                                            "We want to answer your question, sign up for free and get access"
+                                                ++ " to all of CodeTidbit in seconds!"
 
-                                            Nothing ->
-                                                "All Questions"
-                                    , noQuestionsDuringSearchText = "None found"
-                                    , noQuestionsNotDuringSearchText =
-                                        case browseCodePointer of
-                                            Nothing ->
-                                                "Be the first to ask a question"
+                                    Just _ ->
+                                        GoToAskQuestionWithCodePointer bigbitID browseCodePointer
+                            }
+                            remainingQuestions
+                        ]
 
-                                            Just _ ->
-                                                "None found"
-                                    , askQuestion =
-                                        case shared.user of
-                                            Nothing ->
-                                                SetUserNeedsAuthModal <|
-                                                    "We want to answer your question, sign up for free and get access"
-                                                        ++ " to all of CodeTidbit in seconds!"
+                Nothing ->
+                    Util.hiddenDiv
 
-                                            Just _ ->
-                                                GoToAskQuestionWithCodePointer bigbitID browseCodePointer
-                                    }
-                                    remainingQuestions
-                                ]
+        Route.ViewBigbitAskQuestion maybeStoryID bigbitID ->
+            AskQuestion.view
+                { msgTagger = AskQuestionMsg bigbitID
+                , askQuestionRequestInProgress =
+                    RT.isMakingRequest shared.apiRequestTracker (RT.AskQuestion TidbitPointer.Bigbit)
+                , askQuestion = AskQuestion bigbitID
+                , isReadyCodePointer = .range >> Range.isEmptyRange >> not
+                , goToAllQuestions =
+                    GoToBrowseQuestionsWithCodePointer
+                        bigbitID
+                        (QA.getNewQuestion bigbitID model.qaState |||> .codePointer)
+                }
+                (QA.getNewQuestion bigbitID model.qaState ?> QA.defaultNewQuestion)
 
-                    Nothing ->
-                        Util.hiddenDiv
+        Route.ViewBigbitEditQuestion _ bigbitID questionID ->
+            case model.qa ||> .questions |||> QA.getQuestion questionID of
+                Just question ->
+                    let
+                        questionEdit =
+                            QA.getQuestionEdit bigbitID questionID model.qaState
+                                ?> QA.questionEditFromQuestion question
+                    in
+                    EditQuestion.view
+                        { msgTagger = EditQuestionMsg bigbitID question
+                        , editQuestionRequestInProgress =
+                            RT.isMakingRequest shared.apiRequestTracker (RT.UpdateQuestion TidbitPointer.Bigbit)
+                        , isReadyCodePointer = .range >> Range.isEmptyRange >> not
+                        , editQuestion = EditQuestion bigbitID questionID
+                        }
+                        questionEdit
 
-            Route.ViewBigbitAskQuestion maybeStoryID bigbitID ->
-                AskQuestion.view
-                    { msgTagger = AskQuestionMsg bigbitID
-                    , askQuestionRequestInProgress =
-                        RT.isMakingRequest shared.apiRequestTracker (RT.AskQuestion TidbitPointer.Bigbit)
-                    , askQuestion = AskQuestion bigbitID
-                    , isReadyCodePointer = .range >> Range.isEmptyRange >> not
-                    , goToAllQuestions =
-                        GoToBrowseQuestionsWithCodePointer
-                            bigbitID
-                            (QA.getNewQuestion bigbitID model.qaState |||> .codePointer)
-                    }
-                    (QA.getNewQuestion bigbitID model.qaState ?> QA.defaultNewQuestion)
+                Nothing ->
+                    Util.hiddenDiv
 
-            Route.ViewBigbitEditQuestion _ bigbitID questionID ->
-                case model.qa ||> .questions |||> QA.getQuestion questionID of
-                    Just question ->
-                        let
-                            questionEdit =
-                                QA.getQuestionEdit bigbitID questionID model.qaState
-                                    ?> QA.questionEditFromQuestion question
-                        in
-                            EditQuestion.view
-                                { msgTagger = EditQuestionMsg bigbitID question
-                                , editQuestionRequestInProgress =
-                                    RT.isMakingRequest shared.apiRequestTracker (RT.UpdateQuestion TidbitPointer.Bigbit)
-                                , isReadyCodePointer = .range >> Range.isEmptyRange >> not
-                                , editQuestion = EditQuestion bigbitID questionID
-                                }
-                                questionEdit
+        Route.ViewBigbitAnswerQuestion maybeStoryID bigbitID questionID ->
+            case model.qa ||> .questions |||> QA.getQuestion questionID of
+                Just question ->
+                    let
+                        newAnswer =
+                            QA.getNewAnswer bigbitID questionID model.qaState
+                                ?> QA.defaultNewAnswer
+                    in
+                    AnswerQuestion.view
+                        { msgTagger = AnswerQuestionMsg bigbitID question
+                        , forQuestion = question
+                        , answerQuestionRequestInProgress =
+                            RT.isMakingRequest
+                                shared.apiRequestTracker
+                                (RT.AnswerQuestion TidbitPointer.Bigbit)
+                        , goToAllAnswers =
+                            GoTo <|
+                                Route.ViewBigbitAnswersPage
+                                    maybeStoryID
+                                    Nothing
+                                    bigbitID
+                                    questionID
+                        , answerQuestion = AnswerQuestion bigbitID questionID
+                        }
+                        newAnswer
 
-                    Nothing ->
-                        Util.hiddenDiv
+                Nothing ->
+                    Util.hiddenDiv
 
-            Route.ViewBigbitAnswerQuestion maybeStoryID bigbitID questionID ->
-                case model.qa ||> .questions |||> QA.getQuestion questionID of
-                    Just question ->
-                        let
-                            newAnswer =
-                                QA.getNewAnswer bigbitID questionID model.qaState
-                                    ?> QA.defaultNewAnswer
-                        in
-                            AnswerQuestion.view
-                                { msgTagger = AnswerQuestionMsg bigbitID question
-                                , forQuestion = question
-                                , answerQuestionRequestInProgress =
-                                    RT.isMakingRequest
-                                        shared.apiRequestTracker
-                                        (RT.AnswerQuestion TidbitPointer.Bigbit)
-                                , goToAllAnswers =
-                                    GoTo <|
-                                        Route.ViewBigbitAnswersPage
-                                            maybeStoryID
-                                            Nothing
-                                            bigbitID
-                                            questionID
-                                , answerQuestion = AnswerQuestion bigbitID questionID
-                                }
-                                newAnswer
+        Route.ViewBigbitEditAnswer _ bigbitID answerID ->
+            case
+                ( model.qa ||> .answers |||> QA.getAnswer answerID
+                , model.qa |||> QA.getQuestionByAnswerID answerID
+                )
+            of
+                ( Just answer, Just question ) ->
+                    let
+                        answerEdit =
+                            model.qaState
+                                |> QA.getAnswerEdit bigbitID answerID
+                                ?> QA.answerEditFromAnswer answer
+                    in
+                    EditAnswer.view
+                        { msgTagger = EditAnswerMsg bigbitID answer
+                        , editAnswerRequestInProgress =
+                            RT.isMakingRequest shared.apiRequestTracker (RT.UpdateAnswer TidbitPointer.Bigbit)
+                        , editAnswer = EditAnswer bigbitID answerID
+                        , forQuestion = question
+                        }
+                        answerEdit
 
-                    Nothing ->
-                        Util.hiddenDiv
+                _ ->
+                    Util.hiddenDiv
 
-            Route.ViewBigbitEditAnswer _ bigbitID answerID ->
-                case
-                    ( model.qa ||> .answers |||> QA.getAnswer answerID
-                    , model.qa |||> QA.getQuestionByAnswerID answerID
-                    )
-                of
-                    ( Just answer, Just question ) ->
-                        let
-                            answerEdit =
+        Route.ViewBigbitQuestionPage _ _ _ questionID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView qa model.qaState ViewQuestion.QuestionTab question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewBigbitQuestionCommentsPage _ _ _ questionID maybeCommentID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView
+                                qa
                                 model.qaState
-                                    |> QA.getAnswerEdit bigbitID answerID
-                                    ?> QA.answerEditFromAnswer answer
-                        in
-                            EditAnswer.view
-                                { msgTagger = EditAnswerMsg bigbitID answer
-                                , editAnswerRequestInProgress =
-                                    RT.isMakingRequest shared.apiRequestTracker (RT.UpdateAnswer TidbitPointer.Bigbit)
-                                , editAnswer = EditAnswer bigbitID answerID
-                                , forQuestion = question
-                                }
-                                answerEdit
+                                (ViewQuestion.QuestionCommentsTab maybeCommentID)
+                                question
 
-                    _ ->
-                        Util.hiddenDiv
+                        Nothing ->
+                            Util.hiddenDiv
 
-            Route.ViewBigbitQuestionPage _ _ _ questionID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView qa model.qaState ViewQuestion.QuestionTab question
+                Nothing ->
+                    Util.hiddenDiv
 
-                            Nothing ->
-                                Util.hiddenDiv
+        Route.ViewBigbitAnswersPage _ _ _ questionID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView
+                                qa
+                                model.qaState
+                                ViewQuestion.AnswersTab
+                                question
 
-                    Nothing ->
-                        Util.hiddenDiv
+                        Nothing ->
+                            Util.hiddenDiv
 
-            Route.ViewBigbitQuestionCommentsPage _ _ _ questionID maybeCommentID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView
-                                    qa
-                                    model.qaState
-                                    (ViewQuestion.QuestionCommentsTab maybeCommentID)
-                                    question
+                Nothing ->
+                    Util.hiddenDiv
 
-                            Nothing ->
-                                Util.hiddenDiv
+        Route.ViewBigbitAnswerPage _ _ _ answerID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestionByAnswerID answerID qa of
+                        Just question ->
+                            viewQuestionView
+                                qa
+                                model.qaState
+                                (ViewQuestion.AnswerTab answerID)
+                                question
 
-                    Nothing ->
-                        Util.hiddenDiv
+                        Nothing ->
+                            Util.hiddenDiv
 
-            Route.ViewBigbitAnswersPage _ _ _ questionID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView
-                                    qa
-                                    model.qaState
-                                    ViewQuestion.AnswersTab
-                                    question
+                Nothing ->
+                    Util.hiddenDiv
 
-                            Nothing ->
-                                Util.hiddenDiv
+        Route.ViewBigbitAnswerCommentsPage _ _ _ answerID maybeCommentID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestionByAnswerID answerID qa of
+                        Just question ->
+                            viewQuestionView
+                                qa
+                                model.qaState
+                                (ViewQuestion.AnswerCommentsTab answerID maybeCommentID)
+                                question
 
-                    Nothing ->
-                        Util.hiddenDiv
+                        Nothing ->
+                            Util.hiddenDiv
 
-            Route.ViewBigbitAnswerPage _ _ _ answerID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestionByAnswerID answerID qa of
-                            Just question ->
-                                viewQuestionView
-                                    qa
-                                    model.qaState
-                                    (ViewQuestion.AnswerTab answerID)
-                                    question
+                Nothing ->
+                    Util.hiddenDiv
 
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewBigbitAnswerCommentsPage _ _ _ answerID maybeCommentID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestionByAnswerID answerID qa of
-                            Just question ->
-                                viewQuestionView
-                                    qa
-                                    model.qaState
-                                    (ViewQuestion.AnswerCommentsTab answerID maybeCommentID)
-                                    question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            _ ->
-                Util.hiddenDiv
+        _ ->
+            Util.hiddenDiv

--- a/frontend/src/Pages/ViewSnipbit/JSON.elm
+++ b/frontend/src/Pages/ViewSnipbit/JSON.elm
@@ -8,7 +8,7 @@ import JSON.Range
 import JSON.Snipbit
 import JSON.TutorialBookmark
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Models.TutorialBookmark as TB
 import Pages.ViewSnipbit.Model exposing (..)

--- a/frontend/src/Pages/ViewSnipbit/Messages.elm
+++ b/frontend/src/Pages/ViewSnipbit/Messages.elm
@@ -9,7 +9,7 @@ import Elements.Complex.ViewQuestion as ViewQuestion
 import Models.ApiError exposing (ApiError)
 import Models.Completed exposing (Completed, IsCompleted)
 import Models.Opinion exposing (Opinion, PossibleOpinion)
-import Models.QA exposing (SnipbitQA, Question, Answer, QuestionComment, AnswerComment)
+import Models.QA exposing (Answer, AnswerComment, Question, QuestionComment, SnipbitQA)
 import Models.Range exposing (Range)
 import Models.Route exposing (Route)
 import Models.Snipbit exposing (Snipbit)

--- a/frontend/src/Pages/ViewSnipbit/Model.elm
+++ b/frontend/src/Pages/ViewSnipbit/Model.elm
@@ -3,10 +3,10 @@ module Pages.ViewSnipbit.Model exposing (..)
 import DefaultServices.Util as Util exposing (maybeMapWithDefault)
 import Models.Completed exposing (IsCompleted)
 import Models.Opinion exposing (PossibleOpinion)
-import Models.QA exposing (SnipbitQA, SnipbitQuestion, SnipbitQAState)
+import Models.QA exposing (SnipbitQA, SnipbitQAState, SnipbitQuestion)
 import Models.Range exposing (Range)
 import Models.Route as Route
-import Models.Snipbit exposing (Snipbit, HighlightedComment)
+import Models.Snipbit exposing (HighlightedComment, Snipbit)
 import Models.TutorialBookmark as TB
 import Models.ViewerRelevantHC exposing (ViewerRelevantHC, browsingFrames)
 

--- a/frontend/src/Pages/ViewSnipbit/View.elm
+++ b/frontend/src/Pages/ViewSnipbit/View.elm
@@ -12,9 +12,9 @@ import Elements.Complex.EditQuestion as EditQuestion
 import Elements.Complex.ViewQuestion as ViewQuestion
 import Elements.Simple.Editor as Editor
 import Elements.Simple.Markdown as Markdown
-import Elements.Simple.ProgressBar as ProgressBar exposing (TextFormat(Custom), State(..))
+import Elements.Simple.ProgressBar as ProgressBar exposing (State(..), TextFormat(Custom))
 import Elements.Simple.QuestionList as QuestionList
-import Html exposing (Html, div, text, button, i, textarea)
+import Html exposing (Html, button, div, i, text, textarea)
 import Html.Attributes exposing (class, classList, disabled, hidden, id, placeholder, value)
 import Html.Events exposing (onClick, onInput)
 import Models.Completed as Completed
@@ -63,18 +63,18 @@ view model shared =
                                     , "Take Back Love"
                                     )
                     in
-                        button
-                            [ classList
-                                [ ( "sub-bar-button heart-button", True )
-                                , ( "cursor-progress"
-                                  , RT.isMakingRequest
-                                        shared.apiRequestTracker
-                                        (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
-                                  )
-                                ]
-                            , onClick <| newMsg
+                    button
+                        [ classList
+                            [ ( "sub-bar-button heart-button", True )
+                            , ( "cursor-progress"
+                              , RT.isMakingRequest
+                                    shared.apiRequestTracker
+                                    (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                              )
                             ]
-                            [ text buttonText ]
+                        , onClick <| newMsg
+                        ]
+                        [ text buttonText ]
 
                 _ ->
                     Util.hiddenDiv
@@ -212,7 +212,7 @@ view model shared =
                                         _ ->
                                             False
                                     )
-                                        || (isViewSnipbitRHCTabOpen model)
+                                        || isViewSnipbitRHCTabOpen model
                                         || Route.isOnViewSnipbitQARoute shared.route
                                   )
                                 ]
@@ -287,15 +287,14 @@ view model shared =
                                     _ ->
                                         False
                                 )
-                                    && (maybeMapWithDefault
-                                            (not << ViewerRelevantHC.browsingFrames)
-                                            True
-                                            model.relevantHC
-                                       )
+                                    && maybeMapWithDefault
+                                        (not << ViewerRelevantHC.browsingFrames)
+                                        True
+                                        model.relevantHC
                             , textFormat =
                                 Custom
                                     { notStarted = "0%"
-                                    , started = (\frameNumber -> "Frame " ++ (toString frameNumber))
+                                    , started = \frameNumber -> "Frame " ++ toString frameNumber
                                     , done = "100%"
                                     }
                             , shiftLeft = True
@@ -346,12 +345,12 @@ view model shared =
                                         _ ->
                                             False
                                     )
-                                        || (isViewSnipbitRHCTabOpen model)
+                                        || isViewSnipbitRHCTabOpen model
                                         || Route.isOnViewSnipbitQARoute shared.route
                                   )
                                 ]
                             , onClick <|
-                                if (isViewSnipbitRHCTabOpen model) then
+                                if isViewSnipbitRHCTabOpen model then
                                     NoOp
                                 else
                                     case shared.route of
@@ -392,10 +391,9 @@ commentBox snipbit model shared =
                         snipbit.conclusion
 
                     Route.ViewSnipbitFramePage _ _ frameNumber ->
-                        (Array.get
+                        Array.get
                             (frameNumber - 1)
                             snipbit.highlightedComments
-                        )
                             |> Maybe.map .comment
                             |> Maybe.withDefault ""
 
@@ -440,7 +438,7 @@ commentBox snipbit model shared =
                                                     << Route.ViewSnipbitFramePage
                                                         (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
                                                         snipbit.id
-                                                    << ((+) 1)
+                                                    << (+) 1
                                                     << Tuple.first
                                                 )
                                             |> Maybe.withDefault NoOp
@@ -523,16 +521,15 @@ commentBox snipbit model shared =
                             question.id
                             Nothing
                 , goToAnswerTab =
-                    (\answer ->
+                    \answer ->
                         GoTo <|
                             Route.ViewSnipbitAnswerPage
                                 (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
                                 (Route.getTouringQuestionsQueryParamOnViewSnipbitQARoute shared.route)
                                 snipbit.id
                                 answer.id
-                    )
                 , goToAnswerCommentsTab =
-                    (\answer ->
+                    \answer ->
                         GoTo <|
                             Route.ViewSnipbitAnswerCommentsPage
                                 (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
@@ -540,9 +537,8 @@ commentBox snipbit model shared =
                                 snipbit.id
                                 answer.id
                                 Nothing
-                    )
                 , goToQuestionComment =
-                    (\questionComment ->
+                    \questionComment ->
                         GoTo <|
                             Route.ViewSnipbitQuestionCommentsPage
                                 (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
@@ -550,9 +546,8 @@ commentBox snipbit model shared =
                                 snipbit.id
                                 questionComment.questionID
                                 (Just questionComment.id)
-                    )
                 , goToAnswerComment =
-                    (\answerComment ->
+                    \answerComment ->
                         GoTo <|
                             Route.ViewSnipbitAnswerCommentsPage
                                 (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
@@ -560,7 +555,6 @@ commentBox snipbit model shared =
                                 snipbit.id
                                 answerComment.answerID
                                 (Just answerComment.id)
-                    )
                 , goToAnswerQuestion =
                     case shared.user of
                         Just _ ->
@@ -591,14 +585,14 @@ commentBox snipbit model shared =
                 , removeUpvoteQuestion = RateQuestion snipbit.id question.id Nothing
                 , downvoteQuestion = RateQuestion snipbit.id question.id (Just Vote.Downvote)
                 , removeDownvoteQuestion = RateQuestion snipbit.id question.id Nothing
-                , upvoteAnswer = (\answer -> RateAnswer snipbit.id answer.id (Just Vote.Upvote))
-                , removeUpvoteAnswer = (\answer -> RateAnswer snipbit.id answer.id Nothing)
-                , downvoteAnswer = (\answer -> RateAnswer snipbit.id answer.id (Just Vote.Downvote))
-                , removeDownvoteAnswer = (\answer -> RateAnswer snipbit.id answer.id Nothing)
+                , upvoteAnswer = \answer -> RateAnswer snipbit.id answer.id (Just Vote.Upvote)
+                , removeUpvoteAnswer = \answer -> RateAnswer snipbit.id answer.id Nothing
+                , downvoteAnswer = \answer -> RateAnswer snipbit.id answer.id (Just Vote.Downvote)
+                , removeDownvoteAnswer = \answer -> RateAnswer snipbit.id answer.id Nothing
                 , pinQuestion = PinQuestion snipbit.id question.id True
                 , unpinQuestion = PinQuestion snipbit.id question.id False
-                , pinAnswer = (\answer -> PinAnswer snipbit.id answer.id True)
-                , unpinAnswer = (\answer -> PinAnswer snipbit.id answer.id False)
+                , pinAnswer = \answer -> PinAnswer snipbit.id answer.id True
+                , unpinAnswer = \answer -> PinAnswer snipbit.id answer.id False
                 , deleteAnswer = .id >> DeleteAnswer snipbit.id question.id
                 , commentOnQuestion = SubmitCommentOnQuestion snipbit.id question.id
                 , commentOnAnswer = SubmitCommentOnAnswer snipbit.id question.id
@@ -616,224 +610,223 @@ commentBox snipbit model shared =
                 , deletingAnswers = QA.getDeletingAnswers snipbit.id qaState
                 }
     in
-        case shared.route of
-            Route.ViewSnipbitIntroductionPage _ _ ->
-                tutorialRoute
+    case shared.route of
+        Route.ViewSnipbitIntroductionPage _ _ ->
+            tutorialRoute
 
-            Route.ViewSnipbitConclusionPage _ _ ->
-                tutorialRoute
+        Route.ViewSnipbitConclusionPage _ _ ->
+            tutorialRoute
 
-            Route.ViewSnipbitFramePage _ _ _ ->
-                tutorialRoute
+        Route.ViewSnipbitFramePage _ _ _ ->
+            tutorialRoute
 
-            Route.ViewSnipbitQuestionsPage maybeStoryID snipbitID ->
-                case model.qa of
-                    Just { questions } ->
-                        let
-                            ( isHighlighting, remainingQuestions ) =
-                                case QA.getBrowseCodePointer snipbitID model.qaState of
-                                    Nothing ->
+        Route.ViewSnipbitQuestionsPage maybeStoryID snipbitID ->
+            case model.qa of
+                Just { questions } ->
+                    let
+                        ( isHighlighting, remainingQuestions ) =
+                            case QA.getBrowseCodePointer snipbitID model.qaState of
+                                Nothing ->
+                                    ( False, questions )
+
+                                Just codePointer ->
+                                    if Range.isEmptyRange codePointer then
                                         ( False, questions )
-
-                                    Just codePointer ->
-                                        if Range.isEmptyRange codePointer then
-                                            ( False, questions )
-                                        else
-                                            ( True
-                                            , List.filter
-                                                (.codePointer >> Range.overlappingRanges codePointer)
-                                                questions
-                                            )
-                        in
-                            div
-                                [ class "view-questions" ]
-                                [ QuestionList.view
-                                    { questionBoxRenderConfig =
-                                        { onClickQuestionBox =
-                                            (\question ->
-                                                GoTo <|
-                                                    Route.ViewSnipbitQuestionPage
-                                                        (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
-                                                        Nothing
-                                                        snipbitID
-                                                        question.id
-                                            )
-                                        }
-                                    , isHighlighting = isHighlighting
-                                    , allQuestionText = "All Questions"
-                                    , noQuestionsDuringSearchText = "None found"
-                                    , noQuestionsNotDuringSearchText = "Be the first to ask a question"
-                                    , askQuestion =
-                                        case shared.user of
-                                            Just _ ->
-                                                GoToAskQuestion
-
-                                            Nothing ->
-                                                SetUserNeedsAuthModal
-                                                    ("We want to answer your question, sign up for free and get access"
-                                                        ++ " to all of CodeTidbit in seconds!"
-                                                    )
-                                    }
-                                    remainingQuestions
-                                ]
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitQuestionPage maybeStoryID maybeTouringQuestions snipbitID questionID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView qa model.qaState ViewQuestion.QuestionTab question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitAnswersPage maybeStoryID maybeTouringQuestions snipbitID questionID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView qa model.qaState ViewQuestion.AnswersTab question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitAnswerPage maybeStoryID maybeTouringQuestions snipbitID answerID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestionByAnswerID answerID qa of
-                            Just question ->
-                                viewQuestionView qa model.qaState (ViewQuestion.AnswerTab answerID) question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitQuestionCommentsPage maybeStoryID maybeTouringQuestions snipbitID questionID maybeCommentID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestion questionID qa.questions of
-                            Just question ->
-                                viewQuestionView qa model.qaState (ViewQuestion.QuestionCommentsTab maybeCommentID) question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitAnswerCommentsPage maybeStoryID maybeTouringQuestions snipbitID answerID maybeCommentID ->
-                case model.qa of
-                    Just qa ->
-                        case QA.getQuestionByAnswerID answerID qa of
-                            Just question ->
-                                viewQuestionView qa model.qaState (ViewQuestion.AnswerCommentsTab answerID maybeCommentID) question
-
-                            Nothing ->
-                                Util.hiddenDiv
-
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitAskQuestion maybeStoryID snipbitID ->
-                let
-                    newQuestion =
-                        QA.getNewQuestion snipbitID model.qaState
-                            |> Maybe.withDefault QA.defaultNewQuestion
-                in
-                    AskQuestion.view
-                        { msgTagger = AskQuestionMsg snipbitID
-                        , askQuestionRequestInProgress =
-                            RT.isMakingRequest shared.apiRequestTracker (RT.AskQuestion TidbitPointer.Snipbit)
-                        , askQuestion = AskQuestion snipbitID
-                        , isReadyCodePointer = not << Range.isEmptyRange
-                        , goToAllQuestions =
-                            GoToBrowseQuestionsWithCodePointer <|
-                                (QA.getNewQuestion snipbitID model.qaState |||> .codePointer)
-                        }
-                        newQuestion
-
-            Route.ViewSnipbitAnswerQuestion maybeStoryID snipbitID questionID ->
-                case model.qa ||> .questions |||> QA.getQuestion questionID of
-                    Just question ->
-                        AnswerQuestion.view
-                            { msgTagger = AnswerQuestionMsg snipbitID question
-                            , forQuestion = question
-                            , answerQuestionRequestInProgress =
-                                RT.isMakingRequest
-                                    shared.apiRequestTracker
-                                    (RT.AnswerQuestion TidbitPointer.Snipbit)
-                            , answerQuestion = AnswerQuestion snipbitID questionID
-                            , goToAllAnswers =
-                                GoTo <|
-                                    Route.ViewSnipbitAnswersPage
-                                        (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
-                                        (Route.getTouringQuestionsQueryParamOnViewSnipbitQARoute shared.route)
-                                        snipbitID
-                                        questionID
-                            }
-                            (QA.getNewAnswer snipbitID questionID model.qaState
-                                ?> QA.defaultNewAnswer
-                            )
-
-                    -- Will never happen, if the question doesn't exist we will redirect.
-                    Nothing ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitEditQuestion maybeStoryID snipbitID questionID ->
-                case model.qa ||> .questions |||> QA.getQuestion questionID of
-                    Just question ->
-                        let
-                            questionEdit =
-                                QA.getQuestionEdit snipbitID questionID model.qaState
-                                    ?> QA.questionEditFromQuestion question
-                        in
-                            EditQuestion.view
-                                { msgTagger = EditQuestionMsg snipbitID question
-                                , editQuestionRequestInProgress =
-                                    RT.isMakingRequest
-                                        shared.apiRequestTracker
-                                        (RT.UpdateQuestion TidbitPointer.Snipbit)
-                                , isReadyCodePointer = not << Range.isEmptyRange
-                                , editQuestion = EditQuestion snipbitID questionID
+                                    else
+                                        ( True
+                                        , List.filter
+                                            (.codePointer >> Range.overlappingRanges codePointer)
+                                            questions
+                                        )
+                    in
+                    div
+                        [ class "view-questions" ]
+                        [ QuestionList.view
+                            { questionBoxRenderConfig =
+                                { onClickQuestionBox =
+                                    \question ->
+                                        GoTo <|
+                                            Route.ViewSnipbitQuestionPage
+                                                (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
+                                                Nothing
+                                                snipbitID
+                                                question.id
                                 }
-                                questionEdit
+                            , isHighlighting = isHighlighting
+                            , allQuestionText = "All Questions"
+                            , noQuestionsDuringSearchText = "None found"
+                            , noQuestionsNotDuringSearchText = "Be the first to ask a question"
+                            , askQuestion =
+                                case shared.user of
+                                    Just _ ->
+                                        GoToAskQuestion
 
-                    -- This will never happen, if the question doesn't exist we will have redirected URLs.
-                    _ ->
-                        Util.hiddenDiv
-
-            Route.ViewSnipbitEditAnswer maybeStoryID snipbitID answerID ->
-                case
-                    ( model.qa ||> .answers |||> QA.getAnswer answerID
-                    , model.qa |||> QA.getQuestionByAnswerID answerID
-                    )
-                of
-                    ( Just answer, Just question ) ->
-                        EditAnswer.view
-                            { msgTagger = EditAnswerMsg snipbitID answerID answer
-                            , editAnswerRequestInProgress =
-                                RT.isMakingRequest shared.apiRequestTracker (RT.UpdateAnswer TidbitPointer.Snipbit)
-                            , editAnswer = EditAnswer snipbitID question.id answerID
-                            , forQuestion = question
+                                    Nothing ->
+                                        SetUserNeedsAuthModal
+                                            ("We want to answer your question, sign up for free and get access"
+                                                ++ " to all of CodeTidbit in seconds!"
+                                            )
                             }
-                            (QA.getAnswerEdit snipbitID answerID model.qaState
-                                ?> QA.answerEditFromAnswer answer
-                            )
+                            remainingQuestions
+                        ]
 
-                    -- Will never happen, if answer/question don't exist we will redirect.
-                    _ ->
-                        Util.hiddenDiv
+                Nothing ->
+                    Util.hiddenDiv
 
-            _ ->
-                Util.hiddenDiv
+        Route.ViewSnipbitQuestionPage maybeStoryID maybeTouringQuestions snipbitID questionID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView qa model.qaState ViewQuestion.QuestionTab question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitAnswersPage maybeStoryID maybeTouringQuestions snipbitID questionID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView qa model.qaState ViewQuestion.AnswersTab question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitAnswerPage maybeStoryID maybeTouringQuestions snipbitID answerID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestionByAnswerID answerID qa of
+                        Just question ->
+                            viewQuestionView qa model.qaState (ViewQuestion.AnswerTab answerID) question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitQuestionCommentsPage maybeStoryID maybeTouringQuestions snipbitID questionID maybeCommentID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestion questionID qa.questions of
+                        Just question ->
+                            viewQuestionView qa model.qaState (ViewQuestion.QuestionCommentsTab maybeCommentID) question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitAnswerCommentsPage maybeStoryID maybeTouringQuestions snipbitID answerID maybeCommentID ->
+            case model.qa of
+                Just qa ->
+                    case QA.getQuestionByAnswerID answerID qa of
+                        Just question ->
+                            viewQuestionView qa model.qaState (ViewQuestion.AnswerCommentsTab answerID maybeCommentID) question
+
+                        Nothing ->
+                            Util.hiddenDiv
+
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitAskQuestion maybeStoryID snipbitID ->
+            let
+                newQuestion =
+                    QA.getNewQuestion snipbitID model.qaState
+                        |> Maybe.withDefault QA.defaultNewQuestion
+            in
+            AskQuestion.view
+                { msgTagger = AskQuestionMsg snipbitID
+                , askQuestionRequestInProgress =
+                    RT.isMakingRequest shared.apiRequestTracker (RT.AskQuestion TidbitPointer.Snipbit)
+                , askQuestion = AskQuestion snipbitID
+                , isReadyCodePointer = not << Range.isEmptyRange
+                , goToAllQuestions =
+                    GoToBrowseQuestionsWithCodePointer <|
+                        (QA.getNewQuestion snipbitID model.qaState |||> .codePointer)
+                }
+                newQuestion
+
+        Route.ViewSnipbitAnswerQuestion maybeStoryID snipbitID questionID ->
+            case model.qa ||> .questions |||> QA.getQuestion questionID of
+                Just question ->
+                    AnswerQuestion.view
+                        { msgTagger = AnswerQuestionMsg snipbitID question
+                        , forQuestion = question
+                        , answerQuestionRequestInProgress =
+                            RT.isMakingRequest
+                                shared.apiRequestTracker
+                                (RT.AnswerQuestion TidbitPointer.Snipbit)
+                        , answerQuestion = AnswerQuestion snipbitID questionID
+                        , goToAllAnswers =
+                            GoTo <|
+                                Route.ViewSnipbitAnswersPage
+                                    (Route.getFromStoryQueryParamOnViewSnipbitRoute shared.route)
+                                    (Route.getTouringQuestionsQueryParamOnViewSnipbitQARoute shared.route)
+                                    snipbitID
+                                    questionID
+                        }
+                        (QA.getNewAnswer snipbitID questionID model.qaState
+                            ?> QA.defaultNewAnswer
+                        )
+
+                -- Will never happen, if the question doesn't exist we will redirect.
+                Nothing ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitEditQuestion maybeStoryID snipbitID questionID ->
+            case model.qa ||> .questions |||> QA.getQuestion questionID of
+                Just question ->
+                    let
+                        questionEdit =
+                            QA.getQuestionEdit snipbitID questionID model.qaState
+                                ?> QA.questionEditFromQuestion question
+                    in
+                    EditQuestion.view
+                        { msgTagger = EditQuestionMsg snipbitID question
+                        , editQuestionRequestInProgress =
+                            RT.isMakingRequest
+                                shared.apiRequestTracker
+                                (RT.UpdateQuestion TidbitPointer.Snipbit)
+                        , isReadyCodePointer = not << Range.isEmptyRange
+                        , editQuestion = EditQuestion snipbitID questionID
+                        }
+                        questionEdit
+
+                -- This will never happen, if the question doesn't exist we will have redirected URLs.
+                _ ->
+                    Util.hiddenDiv
+
+        Route.ViewSnipbitEditAnswer maybeStoryID snipbitID answerID ->
+            case
+                ( model.qa ||> .answers |||> QA.getAnswer answerID
+                , model.qa |||> QA.getQuestionByAnswerID answerID
+                )
+            of
+                ( Just answer, Just question ) ->
+                    EditAnswer.view
+                        { msgTagger = EditAnswerMsg snipbitID answerID answer
+                        , editAnswerRequestInProgress =
+                            RT.isMakingRequest shared.apiRequestTracker (RT.UpdateAnswer TidbitPointer.Snipbit)
+                        , editAnswer = EditAnswer snipbitID question.id answerID
+                        , forQuestion = question
+                        }
+                        (QA.getAnswerEdit snipbitID answerID model.qaState
+                            ?> QA.answerEditFromAnswer answer
+                        )
+
+                -- Will never happen, if answer/question don't exist we will redirect.
+                _ ->
+                    Util.hiddenDiv
+
+        _ ->
+            Util.hiddenDiv

--- a/frontend/src/Pages/ViewStory/JSON.elm
+++ b/frontend/src/Pages/ViewStory/JSON.elm
@@ -1,7 +1,7 @@
 module Pages.ViewStory.JSON exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.ViewStory.Model exposing (..)
 

--- a/frontend/src/Pages/ViewStory/Update.elm
+++ b/frontend/src/Pages/ViewStory/Update.elm
@@ -3,7 +3,7 @@ module Pages.ViewStory.Update exposing (..)
 import Api
 import DefaultServices.CommonSubPageUtil exposing (CommonSubPageUtil(..), commonSubPageUtil)
 import Models.ContentPointer as ContentPointer
-import Models.Opinion exposing (toPossibleOpinion, PossibleOpinion)
+import Models.Opinion exposing (PossibleOpinion, toPossibleOpinion)
 import Models.Route as Route
 import Pages.Model exposing (Shared)
 import Pages.ViewStory.Messages exposing (..)
@@ -60,23 +60,23 @@ update (Common common) msg model shared =
                                         (OnGetOpinionSuccess << PossibleOpinion contentPointer)
                                     )
                             in
-                                case ( shared.user, model.possibleOpinion ) of
-                                    ( Just user, Just { contentPointer, rating } ) ->
-                                        if contentPointer.contentID == mongoID then
-                                            common.doNothing
-                                        else
-                                            getOpinion
-
-                                    ( Just user, Nothing ) ->
+                            case ( shared.user, model.possibleOpinion ) of
+                                ( Just user, Just { contentPointer, rating } ) ->
+                                    if contentPointer.contentID == mongoID then
+                                        common.doNothing
+                                    else
                                         getOpinion
 
-                                    _ ->
-                                        common.doNothing
+                                ( Just user, Nothing ) ->
+                                    getOpinion
+
+                                _ ->
+                                    common.doNothing
                     in
-                        common.handleAll
-                            [ getStory
-                            , getOpinion
-                            ]
+                    common.handleAll
+                        [ getStory
+                        , getOpinion
+                        ]
 
                 _ ->
                     common.doNothing

--- a/frontend/src/Pages/Welcome/JSON.elm
+++ b/frontend/src/Pages/Welcome/JSON.elm
@@ -1,7 +1,7 @@
 module Pages.Welcome.JSON exposing (..)
 
 import Json.Decode as Decode
-import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Pages.Welcome.Model exposing (..)
 

--- a/frontend/src/Pages/Welcome/Update.elm
+++ b/frontend/src/Pages/Welcome/Update.elm
@@ -46,11 +46,11 @@ update (Common common) msg model shared =
                             OnRegisterFailure
                             OnRegisterSuccess
             in
-                if model.password == model.confirmPassword then
-                    common.makeSingletonRequest RT.LoginOrRegister registerAction
-                else
-                    common.justSetModel
-                        { model | apiError = Just ApiError.PasswordDoesNotMatchConfirmPassword }
+            if model.password == model.confirmPassword then
+                common.makeSingletonRequest RT.LoginOrRegister registerAction
+            else
+                common.justSetModel
+                    { model | apiError = Just ApiError.PasswordDoesNotMatchConfirmPassword }
 
         OnRegisterFailure newApiError ->
             common.justSetModel { model | apiError = Just newApiError }
@@ -69,7 +69,7 @@ update (Common common) msg model shared =
                             OnLoginFailure
                             OnLoginSuccess
             in
-                common.makeSingletonRequest RT.LoginOrRegister loginAction
+            common.makeSingletonRequest RT.LoginOrRegister loginAction
 
         OnLoginSuccess newUser ->
             ( init, { shared | user = Just newUser }, Route.navigateTo Route.BrowsePage )

--- a/frontend/src/Pages/Welcome/View.elm
+++ b/frontend/src/Pages/Welcome/View.elm
@@ -1,8 +1,8 @@
 module Pages.Welcome.View exposing (view)
 
 import DefaultServices.Util as Util
-import Html exposing (Html, div, text, button, h1, input, a, img)
-import Html.Attributes exposing (class, placeholder, type_, value, hidden, disabled, classList, src)
+import Html exposing (Html, a, button, div, h1, img, input, text)
+import Html.Attributes exposing (class, classList, disabled, hidden, placeholder, src, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Models.ApiError as ApiError
 import Models.RequestTracker as RT
@@ -56,9 +56,9 @@ view model shared =
         , div
             [ classList
                 [ ( "welcome-page", True )
-                , ( "small-box-error", (shared.route == Route.LoginPage) && (Util.isNotNothing model.apiError) )
-                , ( "small-box", (shared.route == Route.LoginPage) && (Util.isNothing model.apiError) )
-                , ( "big-box-error", (shared.route == Route.RegisterPage) && (Util.isNotNothing model.apiError) )
+                , ( "small-box-error", (shared.route == Route.LoginPage) && Util.isNotNothing model.apiError )
+                , ( "small-box", (shared.route == Route.LoginPage) && Util.isNothing model.apiError )
+                , ( "big-box-error", (shared.route == Route.RegisterPage) && Util.isNotNothing model.apiError )
                 ]
             ]
             [ displayViewForRoute model shared
@@ -80,11 +80,11 @@ errorBox maybeApiError =
                 Just apiError ->
                     ApiError.humanReadable apiError
     in
-        div
-            [ class "welcome-error-box"
-            , hidden <| Util.isNothing <| maybeApiError
-            ]
-            [ text <| humanReadable <| maybeApiError ]
+    div
+        [ class "welcome-error-box"
+        , hidden <| Util.isNothing <| maybeApiError
+        ]
+        [ text <| humanReadable <| maybeApiError ]
 
 
 {-| The welcome login view
@@ -111,44 +111,44 @@ loginView model shared =
         invalidForm =
             incompleteForm || Util.isNotNothing currentError
     in
-        div
-            []
+    div
+        []
+        [ div
+            [ class "welcome-box" ]
             [ div
-                [ class "welcome-box" ]
-                [ div
-                    [ class "welcome-box-text" ]
-                    [ text "It's Good to Have You Back" ]
-                , div
-                    [ class "welcome-box-sub-text" ]
-                    [ text "Now Go Learn Something Already" ]
-                , input
-                    [ classList [ ( "input-error-highlight", highlightEmail ) ]
-                    , placeholder "Email"
-                    , onInput OnEmailInput
-                    , value model.email
-                    ]
-                    []
-                , div
-                    [ class "gap-15" ]
-                    []
-                , input
-                    [ classList [ ( "input-error-highlight", hightlightPassword ) ]
-                    , placeholder "Password"
-                    , type_ "password"
-                    , onInput OnPasswordInput
-                    , value model.password
-                    ]
-                    []
-                , errorBox currentError
-                , button
-                    [ classList
-                        [ ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.LoginOrRegister ) ]
-                    , onClick Login
-                    , disabled invalidForm
-                    ]
-                    [ text "Login" ]
+                [ class "welcome-box-text" ]
+                [ text "It's Good to Have You Back" ]
+            , div
+                [ class "welcome-box-sub-text" ]
+                [ text "Now Go Learn Something Already" ]
+            , input
+                [ classList [ ( "input-error-highlight", highlightEmail ) ]
+                , placeholder "Email"
+                , onInput OnEmailInput
+                , value model.email
                 ]
+                []
+            , div
+                [ class "gap-15" ]
+                []
+            , input
+                [ classList [ ( "input-error-highlight", hightlightPassword ) ]
+                , placeholder "Password"
+                , type_ "password"
+                , onInput OnPasswordInput
+                , value model.password
+                ]
+                []
+            , errorBox currentError
+            , button
+                [ classList
+                    [ ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.LoginOrRegister ) ]
+                , onClick Login
+                , disabled invalidForm
+                ]
+                [ text "Login" ]
             ]
+        ]
 
 
 {-| The welcome register view
@@ -185,59 +185,59 @@ registerView model shared =
         invalidForm =
             incompleteForm || Util.isNotNothing currentError
     in
-        div
-            [ class "welcome-box" ]
-            [ div
-                [ class "welcome-box-text" ]
-                [ text "Your Friendly Code Learning Platform" ]
-            , div
-                [ class "welcome-box-sub-text" ]
-                [ text "Browse and Create Powerful Tutorials" ]
-            , input
-                [ classList [ ( "input-error-highlight", False ) ]
-                , placeholder "Preferred Name"
-                , onInput OnNameInput
-                , value model.name
-                ]
-                []
-            , div
-                [ class "gap-15" ]
-                []
-            , input
-                [ classList [ ( "input-error-highlight", highlightEmail ) ]
-                , placeholder "Email"
-                , onInput OnEmailInput
-                , value model.email
-                ]
-                []
-            , input
-                [ classList [ ( "input-error-highlight", hightlightPassword ) ]
-                , placeholder "Password"
-                , type_ "password"
-                , onInput OnPasswordInput
-                , value model.password
-                ]
-                []
-            , div
-                [ class "gap-15" ]
-                []
-            , input
-                [ classList [ ( "input-error-highlight", hightlightPassword ) ]
-                , placeholder "Confirm Password"
-                , type_ "password"
-                , onInput OnConfirmPasswordInput
-                , value model.confirmPassword
-                ]
-                []
-            , errorBox currentError
-            , button
-                [ classList
-                    [ ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.LoginOrRegister ) ]
-                , onClick Register
-                , disabled invalidForm
-                ]
-                [ text "Start learning" ]
+    div
+        [ class "welcome-box" ]
+        [ div
+            [ class "welcome-box-text" ]
+            [ text "Your Friendly Code Learning Platform" ]
+        , div
+            [ class "welcome-box-sub-text" ]
+            [ text "Browse and Create Powerful Tutorials" ]
+        , input
+            [ classList [ ( "input-error-highlight", False ) ]
+            , placeholder "Preferred Name"
+            , onInput OnNameInput
+            , value model.name
             ]
+            []
+        , div
+            [ class "gap-15" ]
+            []
+        , input
+            [ classList [ ( "input-error-highlight", highlightEmail ) ]
+            , placeholder "Email"
+            , onInput OnEmailInput
+            , value model.email
+            ]
+            []
+        , input
+            [ classList [ ( "input-error-highlight", hightlightPassword ) ]
+            , placeholder "Password"
+            , type_ "password"
+            , onInput OnPasswordInput
+            , value model.password
+            ]
+            []
+        , div
+            [ class "gap-15" ]
+            []
+        , input
+            [ classList [ ( "input-error-highlight", hightlightPassword ) ]
+            , placeholder "Confirm Password"
+            , type_ "password"
+            , onInput OnConfirmPasswordInput
+            , value model.confirmPassword
+            ]
+            []
+        , errorBox currentError
+        , button
+            [ classList
+                [ ( "cursor-progress", RT.isMakingRequest shared.apiRequestTracker RT.LoginOrRegister ) ]
+            , onClick Register
+            , disabled invalidForm
+            ]
+            [ text "Start learning" ]
+        ]
 
 
 {-| Displays the welcome sub-view based on the sub-route (login or register)

--- a/frontend/src/Ports.elm
+++ b/frontend/src/Ports.elm
@@ -19,6 +19,7 @@ port loadModelFromLocalStorage : () -> Cmd msg
 @param querySelector For finding the element
 @param duration Number of milliseconds for scroll to take.
 @param extraScroll Extra pixels to scroll vertically.
+
 -}
 port doScrolling : { querySelector : String, duration : Int, extraScroll : Int } -> Cmd msg
 

--- a/frontend/src/ProjectTypeAliases.elm
+++ b/frontend/src/ProjectTypeAliases.elm
@@ -72,6 +72,7 @@ type alias QueryParams =
 {-| For when you have a string where the value is irrelevant (currently helpful for query parameter).
 
 NOTE: Only use this type if the value of the string should never be checked and does not matter.
+
 -}
 type alias MeaninglessString =
     String


### PR DESCRIPTION
### Closes

Closes #184


### Description

Switched elm-format, beside automatic changes, had to:
  - Remove useless dup imports (otherwise elm-fmt picks one of the 2, in this case, the wrong one)
  - Had to add `{-| -}`, meaningless module doc-comments, otherwise we get bugs in elm-fmt with the top comment formatting, made an issue [here](https://github.com/avh4/elm-format/issues/380)