### PR TITLE
Closes #212

### DIFF
--- a/frontend/src/Models/RequestTracker.elm
+++ b/frontend/src/Models/RequestTracker.elm
@@ -4,6 +4,7 @@ module Models.RequestTracker exposing (..)
 
 import DefaultServices.InfixFunctions exposing (..)
 import Dict
+import Models.ContentPointer exposing (ContentType)
 import Models.TidbitPointer exposing (TidbitType(..))
 import Pages.Browse.Model exposing (SearchSettings)
 import ProjectTypeAliases exposing (..)
@@ -26,7 +27,7 @@ type TrackedRequest
     | Logout
     | UpdateName
     | UpdateBio
-    | AddOrRemoveOpinion TidbitType
+    | AddOrRemoveOpinion ContentType
     | AskQuestion TidbitType
     | UpdateQuestion TidbitType
     | RateQuestion TidbitType

--- a/frontend/src/Pages/ViewBigbit/Update.elm
+++ b/frontend/src/Pages/ViewBigbit/Update.elm
@@ -570,15 +570,15 @@ update (Common common) msg model shared =
                     common.justProduceCmd <|
                         common.api.post.addOpinion opinion OnAddOpinionFailure (always <| OnAddOpinionSuccess opinion)
             in
-            common.makeSingletonRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit) addOpinionAction
+            common.makeSingletonRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit) addOpinionAction
 
         OnAddOpinionSuccess opinion ->
             common.justSetModel { model | possibleOpinion = Just (Opinion.toPossibleOpinion opinion) }
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit)
 
         OnAddOpinionFailure apiError ->
             common.justSetModalError apiError
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit)
 
         RemoveOpinion opinion ->
             let
@@ -589,18 +589,18 @@ update (Common common) msg model shared =
                             OnRemoveOpinionFailure
                             (always <| OnRemoveOpinionSuccess opinion)
             in
-            common.makeSingletonRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit) removeOpinionAction
+            common.makeSingletonRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit) removeOpinionAction
 
         {- Currently it doesn't matter what opinion we removed because you can only have 1, but it may change in the
            future where we have multiple opinions, then use the `opinion` to figure out which to remove.
         -}
         OnRemoveOpinionSuccess { contentPointer, rating } ->
             common.justSetModel { model | possibleOpinion = Just { contentPointer = contentPointer, rating = Nothing } }
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit)
 
         OnRemoveOpinionFailure apiError ->
             common.justSetModalError apiError
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Bigbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Bigbit)
 
         OnGetExpandedStorySuccess story ->
             common.justSetShared { shared | viewingStory = Just story }

--- a/frontend/src/Pages/ViewBigbit/View.elm
+++ b/frontend/src/Pages/ViewBigbit/View.elm
@@ -18,6 +18,7 @@ import Html.Attributes exposing (class, classList, hidden)
 import Html.Events exposing (onClick)
 import Models.Bigbit as Bigbit
 import Models.Completed as Completed
+import Models.ContentPointer as ContentPointer
 import Models.QA as QA
 import Models.Range as Range
 import Models.Rating as Rating
@@ -79,7 +80,7 @@ view model shared =
                                         { contentPointer = possibleOpinion.contentPointer
                                         , rating = Rating.Like
                                         }
-                                    , "Love it!"
+                                    , "Love It"
                                     )
 
                                 Just rating ->
@@ -95,12 +96,19 @@ view model shared =
                             [ ( "sub-bar-button heart-button", True )
                             , ( "cursor-progress"
                               , RT.isMakingRequest shared.apiRequestTracker <|
-                                    RT.AddOrRemoveOpinion TidbitPointer.Bigbit
+                                    RT.AddOrRemoveOpinion ContentPointer.Bigbit
                               )
                             ]
                         , onClick <| newMsg
                         ]
                         [ text buttonText ]
+
+                ( Nothing, _ ) ->
+                    button
+                        [ class "sub-bar-button heart-button"
+                        , onClick <| SetUserNeedsAuthModal "We want your feedback, sign up for free and get access to all of CodeTidbit in seconds!"
+                        ]
+                        [ text "Love It" ]
 
                 _ ->
                     Util.hiddenDiv

--- a/frontend/src/Pages/ViewSnipbit/Update.elm
+++ b/frontend/src/Pages/ViewSnipbit/Update.elm
@@ -476,15 +476,15 @@ update (Common common) msg model shared =
                     common.justProduceCmd <|
                         common.api.post.addOpinion opinion OnAddOpinionFailure (always <| OnAddOpinionSuccess opinion)
             in
-            common.makeSingletonRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit) addOpinionAction
+            common.makeSingletonRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit) addOpinionAction
 
         OnAddOpinionSuccess opinion ->
             common.justSetModel { model | possibleOpinion = Just (Opinion.toPossibleOpinion opinion) }
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit)
 
         OnAddOpinionFailure apiError ->
             common.justSetModalError apiError
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit)
 
         RemoveOpinion opinion ->
             let
@@ -495,18 +495,18 @@ update (Common common) msg model shared =
                             OnRemoveOpinionFailure
                             (always <| OnRemoveOpinionSuccess opinion)
             in
-            common.makeSingletonRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit) removeOpinionAction
+            common.makeSingletonRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit) removeOpinionAction
 
         {- Currently it doesn't matter what opinion we removed because you can only have 1, but it may change in the
            future where we have multiple opinions, then use the `opinion` to figure out which to remove.
         -}
         OnRemoveOpinionSuccess { contentPointer, rating } ->
             common.justSetModel { model | possibleOpinion = Just { contentPointer = contentPointer, rating = Nothing } }
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit)
 
         OnRemoveOpinionFailure apiError ->
             common.justSetModalError apiError
-                |> common.andFinishRequest (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                |> common.andFinishRequest (RT.AddOrRemoveOpinion ContentPointer.Snipbit)
 
         OnGetExpandedStorySuccess expandedStory ->
             common.justSetShared { shared | viewingStory = Just expandedStory }

--- a/frontend/src/Pages/ViewSnipbit/View.elm
+++ b/frontend/src/Pages/ViewSnipbit/View.elm
@@ -1,10 +1,8 @@
 module Pages.ViewSnipbit.View exposing (..)
 
 import Array
-import DefaultServices.Editable as Editable
 import DefaultServices.InfixFunctions exposing (..)
 import DefaultServices.Util as Util exposing (maybeMapWithDefault)
-import Dict
 import Elements.Complex.AnswerQuestion as AnswerQuestion
 import Elements.Complex.AskQuestion as AskQuestion
 import Elements.Complex.EditAnswer as EditAnswer
@@ -17,7 +15,7 @@ import Elements.Simple.QuestionList as QuestionList
 import Html exposing (Html, button, div, i, text, textarea)
 import Html.Attributes exposing (class, classList, disabled, hidden, id, placeholder, value)
 import Html.Events exposing (onClick, onInput)
-import Models.Completed as Completed
+import Models.ContentPointer as ContentPointer
 import Models.QA as QA
 import Models.Range as Range
 import Models.Rating as Rating
@@ -52,7 +50,7 @@ view model shared =
                                         { contentPointer = possibleOpinion.contentPointer
                                         , rating = Rating.Like
                                         }
-                                    , "Love it!"
+                                    , "Love It"
                                     )
 
                                 Just rating ->
@@ -69,12 +67,19 @@ view model shared =
                             , ( "cursor-progress"
                               , RT.isMakingRequest
                                     shared.apiRequestTracker
-                                    (RT.AddOrRemoveOpinion TidbitPointer.Snipbit)
+                                    (RT.AddOrRemoveOpinion ContentPointer.Snipbit)
                               )
                             ]
                         , onClick <| newMsg
                         ]
                         [ text buttonText ]
+
+                ( Nothing, _ ) ->
+                    button
+                        [ class "sub-bar-button heart-button"
+                        , onClick <| SetUserNeedsAuthModal "We want your feedback, sign up for free and get access to all of CodeTidbit in seconds!"
+                        ]
+                        [ text "Love It" ]
 
                 _ ->
                     Util.hiddenDiv

--- a/frontend/src/Pages/ViewStory/Messages.elm
+++ b/frontend/src/Pages/ViewStory/Messages.elm
@@ -22,3 +22,4 @@ type Msg
     | OnRemoveOpinionFailure ApiError
     | OnGetExpandedStorySuccess ExpandedStory
     | OnGetExpandedStoryFailure ApiError
+    | SetUserNeedsAuthModal String


### PR DESCRIPTION
### Closes

Closes #212 

### Description

Added "Love It" buttons that trigger the "require-auth-modal" on view-story/view-snipbit/view-bigbit.

##### Additionally

The Love It button on the story page wasn't hooked up to RequestTracker so I hooked that up, this should've been already hooked up but somehow it escaped the cracks.