### PR TITLE
Closes #213

### DIFF
--- a/frontend/src/Models/Route.elm
+++ b/frontend/src/Models/Route.elm
@@ -65,8 +65,8 @@ type Route
     | CreateStoryTagsPage (Maybe EditingStoryID)
     | DevelopStoryPage StoryID
     | ProfilePage
-    | LoginPage
-    | RegisterPage
+    | LoginPage (Maybe Link)
+    | RegisterPage (Maybe Link)
     | NotificationsPage
 
 
@@ -268,10 +268,13 @@ matchers =
             s "profile"
 
         register =
-            s "register"
+            s "register" <?> qpFromLink
 
         login =
-            s "login"
+            s "login" <?> qpFromLink
+
+        qpFromLink =
+            stringParam "from"
 
         notifications =
             s "notifications"
@@ -335,10 +338,10 @@ matchers =
 routeRequiresAuth : Route -> Bool
 routeRequiresAuth route =
     case route of
-        LoginPage ->
+        LoginPage _ ->
             False
 
-        RegisterPage ->
+        RegisterPage _ ->
             False
 
         ViewSnipbitIntroductionPage _ _ ->
@@ -414,10 +417,10 @@ logged-out, these are specifically the routes that you must be logged-out to acc
 routeRequiresNotAuth : Route -> Bool
 routeRequiresNotAuth route =
     case route of
-        LoginPage ->
+        LoginPage _ ->
             True
 
-        RegisterPage ->
+        RegisterPage _ ->
             True
 
         _ ->
@@ -435,7 +438,7 @@ defaultAuthRoute =
 -}
 defaultUnauthRoute : Route
 defaultUnauthRoute =
-    RegisterPage
+    RegisterPage Nothing
 
 
 {-| Converts a route to just the part of the url after (and including) the hash.
@@ -718,11 +721,11 @@ toHashUrl route =
                 ProfilePage ->
                     "profile"
 
-                LoginPage ->
-                    "login"
+                LoginPage qpFrom ->
+                    "login" ++ Util.queryParamsToString [ ( "from", qpFrom ) ]
 
-                RegisterPage ->
-                    "register"
+                RegisterPage qpFrom ->
+                    "register" ++ Util.queryParamsToString [ ( "from", qpFrom ) ]
 
                 NotificationsPage ->
                     "notifications"
@@ -1279,3 +1282,18 @@ isOnViewBigbitQARouteWithFS route =
 
         _ ->
             False
+
+
+{-| Returns the "from" QP from the welcome pages (login and register).
+-}
+fromQPOnWelcomePage : Route -> Maybe Link
+fromQPOnWelcomePage route =
+    case route of
+        LoginPage maybeLink ->
+            maybeLink
+
+        RegisterPage maybeLink ->
+            maybeLink
+
+        _ ->
+            Nothing

--- a/frontend/src/Pages/JSON.elm
+++ b/frontend/src/Pages/JSON.elm
@@ -11,6 +11,7 @@ import Json.Decode as Decode
 import Json.Decode.Pipeline exposing (decode, hardcoded, optional, required)
 import Json.Encode as Encode
 import Keyboard.Extra as KK
+import Models.Route as Route
 import Pages.Browse.JSON as BrowseJSON
 import Pages.Create.JSON as CreateJSON
 import Pages.CreateBigbit.JSON as CreateBigbitJSON
@@ -77,7 +78,7 @@ sharedEncoder : Shared -> Encode.Value
 sharedEncoder shared =
     Encode.object
         [ ( "user", justValueOrNull JSON.User.safeEncoder shared.user )
-        , ( "route", JSON.Route.encoder shared.route )
+        , ( "route", Encode.null )
         , ( "languages", Encode.null )
         , ( "keysDown", Encode.null )
         , ( "userStories", Encode.null )
@@ -97,7 +98,7 @@ sharedDecoder : Shared -> Decode.Decoder Shared
 sharedDecoder shared =
     decode Shared
         |> required "user" (Decode.maybe JSON.User.decoder)
-        |> required "route" JSON.Route.decoder
+        |> hardcoded Route.BrowsePage
         |> required "languages" (Decode.succeed Editor.humanReadableListOfLanguages)
         |> required "keysDown" (Decode.succeed KK.init)
         |> hardcoded Nothing

--- a/frontend/src/Pages/Profile/Update.elm
+++ b/frontend/src/Pages/Profile/Update.elm
@@ -120,7 +120,7 @@ update (Common common) msg model shared =
         OnLogOutSuccess basicResponse ->
             -- WARNING (unusual behaviour): The base update will check for this message and reset the entire model.
             -- Because of this there is no need to `andFinishRequest` (in fact that will do nothing).
-            common.justProduceCmd <| Route.navigateTo Route.RegisterPage
+            common.justProduceCmd <| Route.navigateTo <| Route.RegisterPage Nothing
 
         OnLogOutFailure apiError ->
             common.justSetModel { model | logOutError = Just apiError }

--- a/frontend/src/Pages/Update.elm
+++ b/frontend/src/Pages/Update.elm
@@ -712,10 +712,10 @@ handleLocationChange maybeRoute model =
             -- Handle general route-logic here, routes are a great way to be
             -- able to trigger certain things (hooks).
             case route of
-                Route.LoginPage ->
+                Route.LoginPage _ ->
                     triggerRouteHookOnWelcomePage
 
-                Route.RegisterPage ->
+                Route.RegisterPage _ ->
                     triggerRouteHookOnWelcomePage
 
                 Route.BrowsePage ->

--- a/frontend/src/Pages/View.elm
+++ b/frontend/src/Pages/View.elm
@@ -54,7 +54,7 @@ view model =
         , Util.maybeMapWithDefault errorModal Util.hiddenDiv model.shared.apiModalError
 
         -- The modal for telling the user they need to sign up (likely because they clicked something requiring auth).
-        , Util.maybeMapWithDefault signUpModal Util.hiddenDiv model.shared.userNeedsAuthModal
+        , Util.maybeMapWithDefault (signUpModal model.shared.route) Util.hiddenDiv model.shared.userNeedsAuthModal
 
         -- Used for smooth scrolling to the bottom.
         , div [ class "invisible-bottom" ] []
@@ -89,8 +89,8 @@ errorModal apiError =
 
 {-| A basic modal for telling the user that they need to log in or sign up.
 -}
-signUpModal : String -> Html Msg
-signUpModal modalMessage =
+signUpModal : Route.Route -> String -> Html Msg
+signUpModal currentRoute modalMessage =
     div
         [ class "sign-up-modal" ]
         [ -- The modal background.
@@ -113,12 +113,12 @@ signUpModal modalMessage =
                 [ class "centered-buttons" ]
                 [ div
                     [ class "login"
-                    , onClick <| GoTo <| Route.LoginPage
+                    , onClick <| GoTo <| Route.LoginPage (Just <| Route.toHashUrl currentRoute)
                     ]
                     [ text "LOGIN" ]
                 , div
                     [ class "sign-up"
-                    , onClick <| GoTo <| Route.RegisterPage
+                    , onClick <| GoTo <| Route.RegisterPage (Just <| Route.toHashUrl currentRoute)
                     ]
                     [ text "SIGN UP" ]
                 ]
@@ -174,10 +174,10 @@ viewForRoute model =
             notificationsView model.notificationsPage model.shared
     in
     case model.shared.route of
-        Route.RegisterPage ->
+        Route.RegisterPage _ ->
             welcomePage
 
-        Route.LoginPage ->
+        Route.LoginPage _ ->
             welcomePage
 
         Route.BrowsePage ->
@@ -414,10 +414,10 @@ notificationsView notificationsModel shared =
 navbarIfOnRoute : Model -> Html Msg
 navbarIfOnRoute model =
     case model.shared.route of
-        Route.LoginPage ->
+        Route.LoginPage _ ->
             Util.hiddenDiv
 
-        Route.RegisterPage ->
+        Route.RegisterPage _ ->
             Util.hiddenDiv
 
         _ ->
@@ -629,7 +629,7 @@ navbar model =
                 [ ( "nav-btn sign-up right", True )
                 , ( "hidden", Util.isNotNothing shared.user )
                 ]
-            , onClick <| GoTo Route.RegisterPage
+            , onClick <| GoTo <| Route.RegisterPage <| Just <| Route.toHashUrl shared.route
             ]
             [ text "Sign Up" ]
         , div
@@ -637,7 +637,7 @@ navbar model =
                 [ ( "nav-btn login right", True )
                 , ( "hidden", Util.isNotNothing shared.user )
                 ]
-            , onClick <| GoTo Route.LoginPage
+            , onClick <| GoTo <| Route.LoginPage <| Just <| Route.toHashUrl shared.route
             ]
             [ text "Login" ]
         ]

--- a/frontend/src/Pages/Welcome/Update.elm
+++ b/frontend/src/Pages/Welcome/Update.elm
@@ -4,6 +4,7 @@ import DefaultServices.CommonSubPageUtil exposing (CommonSubPageUtil(..))
 import Models.ApiError as ApiError
 import Models.RequestTracker as RT
 import Models.Route as Route
+import Navigation
 import Pages.Model exposing (Shared)
 import Pages.Welcome.Init exposing (..)
 import Pages.Welcome.Messages exposing (..)
@@ -57,7 +58,16 @@ update (Common common) msg model shared =
                 |> common.andFinishRequest RT.LoginOrRegister
 
         OnRegisterSuccess newUser ->
-            ( init, { shared | user = Just newUser }, Route.navigateTo Route.BrowsePage )
+            let
+                redirectCmd =
+                    case Route.fromQPOnWelcomePage shared.route of
+                        Just link ->
+                            Navigation.newUrl link
+
+                        Nothing ->
+                            Route.navigateTo Route.BrowsePage
+            in
+            ( init, { shared | user = Just newUser }, redirectCmd )
                 |> common.andFinishRequest RT.LoginOrRegister
 
         Login ->
@@ -72,7 +82,16 @@ update (Common common) msg model shared =
             common.makeSingletonRequest RT.LoginOrRegister loginAction
 
         OnLoginSuccess newUser ->
-            ( init, { shared | user = Just newUser }, Route.navigateTo Route.BrowsePage )
+            let
+                redirectCmd =
+                    case Route.fromQPOnWelcomePage shared.route of
+                        Just link ->
+                            Navigation.newUrl link
+
+                        Nothing ->
+                            Route.navigateTo Route.BrowsePage
+            in
+            ( init, { shared | user = Just newUser }, redirectCmd )
                 |> common.andFinishRequest RT.LoginOrRegister
 
         OnLoginFailure newApiError ->

--- a/frontend/src/Pages/Welcome/View.elm
+++ b/frontend/src/Pages/Welcome/View.elm
@@ -30,18 +30,18 @@ view model shared =
             [ class "logo-title-2" ]
             [ text "TIDBIT" ]
         , case shared.route of
-            Route.RegisterPage ->
+            Route.RegisterPage from ->
                 button
                     [ class "welcome-page-change-tab-button"
-                    , onClick <| GoTo Route.LoginPage
+                    , onClick <| GoTo <| Route.LoginPage from
                     ]
                     [ text "Login"
                     ]
 
-            Route.LoginPage ->
+            Route.LoginPage from ->
                 button
                     [ class "welcome-page-change-tab-button"
-                    , onClick <| GoTo Route.RegisterPage
+                    , onClick <| GoTo <| Route.RegisterPage from
                     ]
                     [ text "Register"
                     ]
@@ -56,9 +56,30 @@ view model shared =
         , div
             [ classList
                 [ ( "welcome-page", True )
-                , ( "small-box-error", (shared.route == Route.LoginPage) && Util.isNotNothing model.apiError )
-                , ( "small-box", (shared.route == Route.LoginPage) && Util.isNothing model.apiError )
-                , ( "big-box-error", (shared.route == Route.RegisterPage) && Util.isNotNothing model.apiError )
+                , ( "small-box-error"
+                  , case ( model.apiError, shared.route ) of
+                        ( Just _, Route.LoginPage _ ) ->
+                            True
+
+                        _ ->
+                            False
+                  )
+                , ( "small-box"
+                  , case ( model.apiError, shared.route ) of
+                        ( Nothing, Route.LoginPage _ ) ->
+                            True
+
+                        _ ->
+                            False
+                  )
+                , ( "big-box-error"
+                  , case ( model.apiError, shared.route ) of
+                        ( Just _, Route.RegisterPage _ ) ->
+                            True
+
+                        _ ->
+                            False
+                  )
                 ]
             ]
             [ displayViewForRoute model shared
@@ -245,10 +266,10 @@ registerView model shared =
 displayViewForRoute : Model -> Shared -> Html Msg
 displayViewForRoute model shared =
     case shared.route of
-        Route.LoginPage ->
+        Route.LoginPage _ ->
             loginView model shared
 
-        Route.RegisterPage ->
+        Route.RegisterPage _ ->
             registerView model shared
 
         _ ->


### PR DESCRIPTION
### Closes

Closes #213 

### Description

- We no longer encode/decode Route, that won't be helpful
  but it can be harmful because if I change the route
  like I did here then it could ruin someones localStorage
  cache. Best to not pointlessly encode/decode it.
- We now have an extra query param on the login/register pages
  to take a "from" link, which they will go to upon succesful
  login/register.
- Login/Signup buttons at the top now attach QP so that it keeps
  track of where the user was.
- Login/Signup on the modal also attach the QP so again it takes
  the user back to the page they were on. This makes it less disruptive.

